### PR TITLE
[WIP] Adding ALIAS record support for DynECT in Record Store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'ejson'
 gem 'fog'
 gem 'fog-json'
 gem 'fog-xml'
-gem 'fog-dynect'
+gem 'fog-dynect', :git => 'https://github.com/Shopify/fog-dynect.git', :branch => 'alias-record-support'
 
 group :test do
   gem 'mocha'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'ejson'
 gem 'fog'
 gem 'fog-json'
 gem 'fog-xml'
-gem 'fog-dynect', :git => 'https://github.com/Shopify/fog-dynect.git'
+gem 'fog-dynect', :git => 'https://github.com/fog/fog-dynect.git'
 
 group :test do
   gem 'mocha'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'ejson'
 gem 'fog'
 gem 'fog-json'
 gem 'fog-xml'
-gem 'fog-dynect', :git => 'https://github.com/Shopify/fog-dynect.git', :branch => 'alias-record-support'
+gem 'fog-dynect', :git => 'https://github.com/Shopify/fog-dynect.git'
 
 group :test do
   gem 'mocha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/Shopify/fog-dynect.git
+  revision: b08eb45f3c79423bfd39e3260f07556a873fbabb
+  specs:
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -67,10 +76,6 @@ GEM
       mime-types
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-    fog-dynect (0.0.2)
-      fog-core
-      fog-json
-      fog-xml
     fog-ecloud (0.3.0)
       fog-core
       fog-xml
@@ -165,7 +170,7 @@ DEPENDENCIES
   activesupport (~> 4.2)
   ejson
   fog
-  fog-dynect
+  fog-dynect!
   fog-json
   fog-xml
   mocha
@@ -175,4 +180,4 @@ DEPENDENCIES
   vcr
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/Shopify/fog-dynect.git
-  revision: b08eb45f3c79423bfd39e3260f07556a873fbabb
+  remote: https://github.com/fog/fog-dynect.git
+  revision: 5b8a461aedcc2b80c53ea020a2364922cae8edac
   specs:
     fog-dynect (0.0.3)
       fog-core

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -2,6 +2,10 @@ require 'fog/dynect'
 
 module RecordStore
   class Provider::DynECT < Provider
+    def self.record_types
+      super.add('ALIAS')
+    end
+
     def freeze_zone
       session.put_zone(@zone_name, freeze: true)
     end

--- a/lib/record_store/record/alias.rb
+++ b/lib/record_store/record/alias.rb
@@ -1,20 +1,20 @@
 module RecordStore
   class Record::ALIAS < Record
-    attr_accessor :t
+    attr_accessor :alias_value
 
-    validates :t, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
+    validates :alias_value, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
 
     def initialize(record)
       super
-      @t = Record.ensure_ends_with_dot(record.fetch(:t))
+      @alias_value = Record.ensure_ends_with_dot(record.fetch(:alias))
     end
 
     def rdata
-      { t: t }
+      { alias: alias_value }
     end
 
     def to_s
-      "[ALIASRecord] #{fqdn} #{ttl} IN ALIAS #{t}"
+      "[ALIASRecord] #{fqdn} #{ttl} IN ALIAS #{alias_value}"
     end
   end
 end

--- a/lib/record_store/record/alias.rb
+++ b/lib/record_store/record/alias.rb
@@ -1,20 +1,20 @@
 module RecordStore
   class Record::ALIAS < Record
-    attr_accessor :alias
+    attr_accessor :t
 
-    validates :alias, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
+    validates :t, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
 
     def initialize(record)
       super
-      @alias = Record.ensure_ends_with_dot(record.fetch(:alias))
+      @t = Record.ensure_ends_with_dot(record.fetch(:t))
     end
 
     def rdata
-      { alias: alias }
+      { t: t }
     end
 
     def to_s
-      "[ALIASRecord] #{fqdn} #{ttl} IN ALIAS #{alias}"
+      "[ALIASRecord] #{fqdn} #{ttl} IN ALIAS #{t}"
     end
   end
 end

--- a/lib/record_store/record/alias.rb
+++ b/lib/record_store/record/alias.rb
@@ -1,20 +1,24 @@
 module RecordStore
   class Record::ALIAS < Record
-    attr_accessor :alias_value
+    attr_accessor :cname
 
-    validates :alias_value, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
+    validates :cname, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
 
     def initialize(record)
       super
-      @alias_value = Record.ensure_ends_with_dot(record.fetch(:alias))
+      if record.has_key?(:cname)
+        @cname = Record.ensure_ends_with_dot(record.fetch(:cname))
+      elsif record.has_key?(:alias)
+        @cname = Record.ensure_ends_with_dot(record.fetch(:alias))
+      end
     end
 
     def rdata
-      { alias: alias_value }
+        { alias: cname, cname: cname }
     end
 
     def to_s
-      "[ALIASRecord] #{fqdn} #{ttl} IN ALIAS #{alias_value}"
+      "[ALIASRecord] #{fqdn} #{ttl} IN ALIAS #{cname}"
     end
   end
 end

--- a/lib/record_store/record/alias.rb
+++ b/lib/record_store/record/alias.rb
@@ -1,20 +1,20 @@
 module RecordStore
   class Record::ALIAS < Record
-    attr_accessor :cname
+    attr_accessor :alias
 
-    validates :cname, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
+    validates :alias, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
 
     def initialize(record)
       super
-      @cname = Record.ensure_ends_with_dot(record.fetch(:cname))
+      @cname = Record.ensure_ends_with_dot(record.fetch(:alias))
     end
 
     def rdata
-      { cname: cname }
+      { alias: cname }
     end
 
     def to_s
-      "[ALIASRecord] #{fqdn} #{ttl} IN ALIAS #{cname}"
+      "[ALIASRecord] #{fqdn} #{ttl} IN ALIAS #{alias}"
     end
   end
 end

--- a/lib/record_store/record/alias.rb
+++ b/lib/record_store/record/alias.rb
@@ -6,7 +6,7 @@ module RecordStore
 
     def initialize(record)
       super
-      @cname = Record.ensure_ends_with_dot(record.fetch(:alias))
+      @alias = Record.ensure_ends_with_dot(record.fetch(:alias))
     end
 
     def rdata

--- a/lib/record_store/record/alias.rb
+++ b/lib/record_store/record/alias.rb
@@ -10,7 +10,7 @@ module RecordStore
     end
 
     def rdata
-      { alias: cname }
+      { alias: alias }
     end
 
     def to_s

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -173,8 +173,8 @@ class DynECTTest < Minitest::Test
 
   def test_apply_changeset_sets_state_to_match_changeset
     a_record = Record::ALIAS.new(
-      fqdn: 'dns-test-dyn.shopify.io',
-      zone: 'shopify.io',
+      fqdn: 'alias-test.dns-test-dyn.shopify.io',
+      zone: 'dns-test-dyn.shopify.io',
       ttl: 86400,
       alias: 'meaniepies.myshopify.com'
     )

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -48,13 +48,13 @@ class DynECTTest < Minitest::Test
       "zone" => zone_name,
       "ttl" => 60,
       "fqdn" => "alias.dns-test.ec2.shopify.com",
-      "record_type" => "AAAA",
+      "record_type" => "ALIAS",
       "rdata" => {
         "address" => "2001:0db8:85a3:0000:0000:EA75:1337:BEEF"
       }
     })
 
-    assert_kind_of Record::AAAA, record
+    assert_kind_of Record::ALIAS, record
     assert_equal 'aaaa.dns-test.shopify.io.', record.fqdn
     assert_equal '2001:0db8:85a3:0000:0000:EA75:1337:BEEF', record.address
     assert_equal 60, record.ttl

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -42,18 +42,18 @@ class DynECTTest < Minitest::Test
 
   def test_build_alias_from_api
     record = @dyn.send(:build_from_api, {
-      "zone" => 'dns-test.shopify.io',
+      "zone" => 'dns-test-dyn.shopify.io',
       "ttl" => 60,
-      "fqdn" => "alias.dns-test.shopify.io",
+      "fqdn" => "meaniepies.myshopify.com",
       "record_type" => "ALIAS",
       "rdata" => {
-        "alias" => "dns-test.shopify.io."
+        "alias" => "meaniepies.myshopify.com."
       }
     })
 
     assert_kind_of Record::ALIAS, record
-    assert_equal 'alias.dns-test.shopify.io.', record.fqdn
-    assert_equal 'dns-test.shopify.io.', record.cname
+    assert_equal 'meaniepies.myshopify.com.', record.fqdn
+    assert_equal 'meaniepies.myshopify.com.', record.cname
     assert_equal 60, record.ttl
   end
 
@@ -172,7 +172,12 @@ class DynECTTest < Minitest::Test
   end
 
   def test_apply_changeset_sets_state_to_match_changeset
-    a_record = Record::A.new(fqdn: 'test-record.dns-test.shopify.io.', ttl: 86400, address: '10.10.10.42')
+    a_record = Record::ALIAS.new(
+      fqdn: 'shopify.io',
+      zone: 'dns-test-dyn.shopify.io',
+      ttl: 86400,
+      alias: 'meaniepies.myshopify.com'
+    )
 
     VCR.use_cassette('dynect_apply_changeset', :record => :all) do
       @dyn.apply_changeset(Changeset.new(

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -44,19 +44,19 @@ class DynECTTest < Minitest::Test
     zone_name = 'dns-test.ec2.shopify.com'
     dyn = Provider::DynECT.new(zone: zone_name)
 
-    record = @dyn.send(:build_from_api, {
+    record = dyn.send(:build_from_api, {
       "zone" => zone_name,
       "ttl" => 60,
-      "fqdn" => "alias.dns-test.ec2.shopify.com",
+      "fqdn" => "dns-test.ec2.shopify.com",
       "record_type" => "ALIAS",
       "rdata" => {
-        "address" => "2001:0db8:85a3:0000:0000:EA75:1337:BEEF"
+        "cname" => "alias.dns-test.ec2.shopify.com."
       }
     })
 
     assert_kind_of Record::ALIAS, record
-    assert_equal 'aaaa.dns-test.shopify.io.', record.fqdn
-    assert_equal '2001:0db8:85a3:0000:0000:EA75:1337:BEEF', record.address
+    assert_equal 'dns-test.ec2.shopify.com.', record.fqdn
+    assert_equal 'alias.dns-test.ec2.shopify.com.', record.cname
     assert_equal 60, record.ttl
   end
 

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -47,13 +47,13 @@ class DynECTTest < Minitest::Test
       "fqdn" => "alias.dns-test.shopify.io",
       "record_type" => "ALIAS",
       "rdata" => {
-        "cname" => "dns-test.shopify.io."
+        "alias" => "dns-test.shopify.io."
       }
     })
 
     assert_kind_of Record::ALIAS, record
     assert_equal 'alias.dns-test.shopify.io.', record.fqdn
-    assert_equal 'dns-test.shopify.io.', record.cname
+    assert_equal 'dns-test.shopify.io.', record.alias
     assert_equal 60, record.ttl
   end
 

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -41,22 +41,19 @@ class DynECTTest < Minitest::Test
   end
 
   def test_build_alias_from_api
-    zone_name = 'dns-test.ec2.shopify.com'
-    dyn = Provider::DynECT.new(zone: zone_name)
-
-    record = dyn.send(:build_from_api, {
-      "zone" => zone_name,
+    record = @dyn.send(:build_from_api, {
+      "zone" => 'dns-test.shopify.io',
       "ttl" => 60,
-      "fqdn" => "dns-test.ec2.shopify.com",
+      "fqdn" => "alias.dns-test.shopify.io",
       "record_type" => "ALIAS",
       "rdata" => {
-        "cname" => "alias.dns-test.ec2.shopify.com."
+        "cname" => "dns-test.shopify.io."
       }
     })
 
     assert_kind_of Record::ALIAS, record
-    assert_equal 'dns-test.ec2.shopify.com.', record.fqdn
-    assert_equal 'alias.dns-test.ec2.shopify.com.', record.cname
+    assert_equal 'alias.dns-test.shopify.io.', record.fqdn
+    assert_equal 'dns-test.shopify.io.', record.cname
     assert_equal 60, record.ttl
   end
 

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -40,6 +40,26 @@ class DynECTTest < Minitest::Test
     assert_equal 60, record.ttl
   end
 
+  def test_build_alias_from_api
+    zone_name = 'dns-test.ec2.shopify.com'
+    dyn = Provider::DynECT.new(zone: zone_name)
+
+    record = @dyn.send(:build_from_api, {
+      "zone" => zone_name,
+      "ttl" => 60,
+      "fqdn" => "alias.dns-test.ec2.shopify.com",
+      "record_type" => "AAAA",
+      "rdata" => {
+        "address" => "2001:0db8:85a3:0000:0000:EA75:1337:BEEF"
+      }
+    })
+
+    assert_kind_of Record::AAAA, record
+    assert_equal 'aaaa.dns-test.shopify.io.', record.fqdn
+    assert_equal '2001:0db8:85a3:0000:0000:EA75:1337:BEEF', record.address
+    assert_equal 60, record.ttl
+  end
+
   def test_build_cname_from_api
     record = @dyn.send(:build_from_api, {
       "zone" => "dns-test.shopify.io",

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -173,8 +173,8 @@ class DynECTTest < Minitest::Test
 
   def test_apply_changeset_sets_state_to_match_changeset
     a_record = Record::ALIAS.new(
-      fqdn: 'shopify.io',
-      zone: 'dns-test-dyn.shopify.io',
+      fqdn: 'dns-test-dyn.shopify.io',
+      zone: 'shopify.io',
       ttl: 86400,
       alias: 'meaniepies.myshopify.com'
     )

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -174,7 +174,7 @@ class DynECTTest < Minitest::Test
   def test_apply_changeset_sets_state_to_match_changeset
     a_record = Record::A.new(fqdn: 'test-record.dns-test.shopify.io.', ttl: 86400, address: '10.10.10.42')
 
-    VCR.use_cassette 'dynect_apply_changeset' do
+    VCR.use_cassette('dynect_apply_changeset', :record => :all) do
       @dyn.apply_changeset(Changeset.new(
         current_records: [],
         desired_records: [a_record]

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -53,7 +53,7 @@ class DynECTTest < Minitest::Test
 
     assert_kind_of Record::ALIAS, record
     assert_equal 'alias.dns-test.shopify.io.', record.fqdn
-    assert_equal 'dns-test.shopify.io.', record.alias
+    assert_equal 'dns-test.shopify.io.', record.cname
     assert_equal 60, record.ttl
   end
 

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -47,14 +47,6 @@ class ZoneTest < Minitest::Test
     assert_instance_of Zone::Config, zone.config
   end
 
-  def test_zone_is_invalid_if_provider_does_not_support_record_type
-    zone = Zone.find('empty.com')
-    assert_equal 'DynECT', zone.config.provider
-    zone.records = [Record::ALIAS.new(fqdn: zone.name, ttl: 60, cname: "alias.#{zone.name}")]
-
-    refute_predicate zone, :valid?
-  end
-
   def test_zone_is_not_valid_unless_config_is
     zone = Zone.find('empty.com')
     zone.config = build_config(provider: 'BadProvider')


### PR DESCRIPTION
r/ @es

- This PR allows DynECT zones to use ALIAS dns entries.
- It also uses a vendored version of the `fog-dynect` gem created here: https://github.com/Shopify/fog-dynect that allows ALIAS records to be used when interfacing with DynECT.

Related: https://github.com/Shopify/growth_engineering/issues/219

Note: Hasn't been 🎩-ted yet, our zones need to be granted the ability to use ALIAS records first. 