### PR TITLE
Validates that all records with matching FQDN and type share the same TTL

### DIFF
--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -108,7 +108,6 @@ module RecordStore
     validate :validate_records
     validate :validate_config
     validate :validate_all_records_are_unique
-    validate :validate_a_records_for_same_fqdn
     validate :validate_cname_records_for_same_fqdn
     validate :validate_cname_records_dont_point_to_root
     validate :validate_same_ttl_for_records_sharing_fqdn_and_type
@@ -191,15 +190,6 @@ module RecordStore
       duplicates = records.select { |r| records.count(r) > 1 }
       duplicates.uniq.each do |record|
         errors.add(:records, "Duplicate record: #{record}")
-      end
-    end
-
-    def validate_a_records_for_same_fqdn
-      a_records = records.select { |record| record.is_a?(Record::A) }.group_by(&:fqdn)
-      a_records.each do |fqdn, records|
-        if records.map(&:ttl).uniq.size > 1
-          errors.add(:records, "All A records for #{fqdn} should have the same TTL")
-        end
       end
     end
 

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -111,6 +111,7 @@ module RecordStore
     validate :validate_a_records_for_same_fqdn
     validate :validate_cname_records_for_same_fqdn
     validate :validate_cname_records_dont_point_to_root
+    validate :validate_same_ttl_for_records_sharing_fqdn_and_type
     validate :validate_provider_can_handle_zone_records
 
     def self.from_yaml_definition(name, definition)
@@ -198,6 +199,16 @@ module RecordStore
       a_records.each do |fqdn, records|
         if records.map(&:ttl).uniq.size > 1
           errors.add(:records, "All A records for #{fqdn} should have the same TTL")
+        end
+      end
+    end
+
+    def validate_same_ttl_for_records_sharing_fqdn_and_type
+      records_sharing_fqdn_and_type = records.group_by { |record| [record.type, record.fqdn] }
+      records_sharing_fqdn_and_type.each do |(type, fqdn), matching_records|
+        all_ttls = matching_records.map(&:ttl).uniq
+        if all_ttls.length > 1
+          errors.add(:records, "All #{type} records for #{fqdn} should have the same TTL")
         end
       end
     end


### PR DESCRIPTION
I am not sure if this is part of the DNS standard, or whether this is a limitation of just DynECT. But I think it makes sense to enforce this anyway.

Fixes #5. For review: @es and @andrewlouis93 