### PR TITLE
Make Record::ALIAS use the alias attribute

### DIFF
--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -19,7 +19,7 @@ module RecordStore
 
       if record.type == 'ALIAS'
         txt_alias = retrieve_current_records.detect do |rr|
-          rr.type == 'TXT' && rr.fqdn == record.fqdn && rr.txtdata == "ALIAS for #{record.cname.gsub(/.\z/, '')}"
+          rr.type == 'TXT' && rr.fqdn == record.fqdn && rr.txtdata == "ALIAS for #{record.alias.gsub(/.\z/, '')}"
         end
         remove(txt_alias)
       end
@@ -93,7 +93,7 @@ module RecordStore
       when 'AAAA'
         record.merge!(address: api_record.fetch('content'))
       when 'ALIAS'
-        record.merge!(cname: api_record.fetch('content'))
+        record.merge!(alias: api_record.fetch('content'))
       when 'CNAME'
         record.merge!(cname: api_record.fetch('content'))
       when 'MX'
@@ -135,7 +135,7 @@ module RecordStore
       when 'AAAA'
         record_hash[:content] = record.address
       when 'ALIAS'
-        record_hash[:content] = record.cname.gsub(/.\z/, '')
+        record_hash[:content] = record.alias.gsub(/.\z/, '')
       when 'CNAME'
         record_hash[:content] = record.cname.gsub(/.\z/, '')
       when 'MX'

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -92,11 +92,6 @@ module RecordStore
 
       return if record_type == 'SOA'
 
-      case record_type
-      when 'ALIAS'
-        record[:cname] = record.delete(:alias)
-      end
-
       unless record.fetch(:fqdn).ends_with?('.')
         record[:fqdn] = "#{record.fetch(:fqdn)}."
       end

--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -18,6 +18,12 @@ module RecordStore
     end
 
     def self.build_from_yaml_definition(yaml_definition)
+      case yaml_definition.fetch(:type)
+      when 'ALIAS'
+        if yaml_definition.key?(:cname)
+          yaml_definition[:alias] = yaml_definition.delete(:cname)
+        end
+      end
       Record.const_get(yaml_definition.fetch(:type)).new(yaml_definition)
     end
 

--- a/lib/record_store/record/alias.rb
+++ b/lib/record_store/record/alias.rb
@@ -1,24 +1,20 @@
 module RecordStore
   class Record::ALIAS < Record
-    attr_accessor :cname
+    attr_accessor :alias
 
-    validates :cname, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
+    validates :alias, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
 
     def initialize(record)
       super
-      @cname = Record.ensure_ends_with_dot(record.fetch(:cname))
+      @alias = Record.ensure_ends_with_dot(record.fetch(:alias))
     end
 
     def rdata
-      { alias: cname }
-    end
-
-    def to_hash
-      super.slice!(:alias).merge(cname: cname)
+      { alias: self.alias }
     end
 
     def to_s
-      "[ALIASRecord] #{fqdn} #{ttl} IN ALIAS #{cname}"
+      "[ALIASRecord] #{fqdn} #{ttl} IN ALIAS #{self.alias}"
     end
   end
 end

--- a/test/providers/dnsimple_test.rb
+++ b/test/providers/dnsimple_test.rb
@@ -65,7 +65,7 @@ class DNSimpleTest < Minitest::Test
 
     assert_kind_of Record::ALIAS, record
     assert_equal 'alias.dns-scratch.me.', record.fqdn
-    assert_equal 'dns-scratch.me.', record.cname
+    assert_equal 'dns-scratch.me.', record.alias
     assert_equal 60, record.ttl
   end
 
@@ -208,7 +208,7 @@ class DNSimpleTest < Minitest::Test
   end
 
   def test_apply_changeset_with_alias_cleans_up_txt_record
-    alias_record = Record::ALIAS.new(fqdn: 'dns-scratch.me.', ttl: 86400, cname: 'alias.dns-scratch.me.')
+    alias_record = Record::ALIAS.new(fqdn: 'dns-scratch.me.', ttl: 86400, alias: 'alias.dns-scratch.me.')
 
     VCR.use_cassette 'dnsimple_apply_changeset_with_alias' do
       @dnsimple.apply_changeset(Changeset.new(

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -54,7 +54,7 @@ class DynECTTest < Minitest::Test
 
     assert_kind_of Record::ALIAS, record
     assert_equal 'alias.dns-test.shopify.io.', record.fqdn
-    assert_equal 'dns-test.shopify.io.', record.cname
+    assert_equal 'dns-test.shopify.io.', record.alias
     assert_equal 60, record.ttl
   end
 

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -53,7 +53,7 @@ class ZoneTest < Minitest::Test
 
     zone = Zone.find('empty.com')
     assert_equal 'DynECT', zone.config.provider
-    zone.records = [Record::ALIAS.new(fqdn: zone.name, ttl: 60, cname: "alias.#{zone.name}")]
+    zone.records = [Record::ALIAS.new(fqdn: zone.name, ttl: 60, alias: "alias.#{zone.name}")]
 
     refute_predicate zone, :valid?
   end


### PR DESCRIPTION
Makes Record::ALIAS use the alias attribute instead of the cname attribute. 

@es @sbfaulkner 