### PR TITLE
Support multiple providers for individual zones

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -5,6 +5,7 @@ require 'bundler/setup'
 require 'record_store'
 
 RecordStore.zones_path = File.expand_path('../../dev/zones', __FILE__)
+RecordStore.config_path = File.expand_path('../../dev/config.yml', __FILE__)
 
-require 'irb'
-IRB.start
+require 'pry'
+binding.pry(RecordStore)

--- a/lib/record_store/changeset.rb
+++ b/lib/record_store/changeset.rb
@@ -33,13 +33,32 @@ module RecordStore
       end
     end
 
-    attr_reader :current_records, :desired_records, :removals, :additions, :updates
+    attr_reader :current_records, :desired_records, :removals, :additions, :updates, :provider, :zone
 
-    def initialize(current_records: [], desired_records: [])
-      @current_records, @desired_records = Set.new(current_records), Set.new(desired_records)
+    def self.build_from(provider:, zone:)
+      current_zone = provider.build_zone(zone_name: zone.name, config: zone.config)
+
+      self.new(
+        current_records: current_zone.records,
+        desired_records: zone.records,
+        provider: provider,
+        zone: current_zone.name # grabs the name from current_zone so that providers can format the name as needed
+      )
+    end
+
+    def initialize(current_records: [], desired_records: [], provider:, zone:)
+      @current_records = Set.new(current_records)
+      @desired_records = Set.new(desired_records)
+      @provider = provider
+      @zone = zone
+
       @additions, @removals, @updates = [], [], []
 
       build_changeset
+    end
+
+    def apply
+      provider.apply_changeset(self)
     end
 
     def unchanged

--- a/lib/record_store/changeset.rb
+++ b/lib/record_store/changeset.rb
@@ -36,13 +36,13 @@ module RecordStore
     attr_reader :current_records, :desired_records, :removals, :additions, :updates, :provider, :zone
 
     def self.build_from(provider:, zone:)
-      current_zone = provider.build_zone(zone_name: zone.name, config: zone.config)
+      current_zone = provider.build_zone(zone_name: zone.unrooted_name, config: zone.config)
 
       self.new(
         current_records: current_zone.records,
         desired_records: zone.records,
         provider: provider,
-        zone: current_zone.name # grabs the name from current_zone so that providers can format the name as needed
+        zone: zone.unrooted_name
       )
     end
 

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -11,16 +11,18 @@ module RecordStore
     desc 'thaw', 'Thaws all zones under management to allow manual edits'
     def thaw
       Zone.each do |_, zone|
-        # TODO(es): fix assumption of single provider
-        zone.provider.thaw if zone.provider.thawable?
+        zone.providers.each do |provider|
+          provider.thaw_zone(zone.unrooted_name) if provider.thawable?
+        end
       end
     end
 
     desc 'freeze', 'Freezes all zones under management to prevent manual edits'
     def freeze
       Zone.each do |_, zone|
-        # TODO(es): fix assumption of single provider
-        zone.provider.freeze_zone if zone.provider.freezable?
+        zone.providers.each do |provider|
+          provider.freeze_zone(zone.unrooted_name) if provider.freezable?
+        end
       end
     end
 

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -120,11 +120,8 @@ module RecordStore
     desc 'reformat', 'Sorts and re-outputs the zone (or all zones) as specified format (file)'
     def reformat
       name = options['name']
-      zones = if name
-        [Zone.find(name)]
-      else
-        Zone.all
-      end
+      zones = name ? [Zone.find(name)] : Zone.all
+
       zones.each do |zone|
         puts "Writing #{zone.name}"
         zone.write(format: options.fetch('format').to_sym)

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -1,40 +1,42 @@
 module RecordStore
   class Provider
-    def self.provider_for(zone_name)
-      dns = Resolv::DNS.new(nameserver: ['8.8.8.8', '8.8.4.4'])
+    class << self
+      def provider_for(zone_name)
+        dns = Resolv::DNS.new(nameserver: ['8.8.8.8', '8.8.4.4'])
 
-      begin
-        ns_server = dns.getresource(zone_name, Resolv::DNS::Resource::IN::SOA).mname.to_s
-      rescue Resolv::ResolvError => e
-        abort "Domain doesn't exist"
+        begin
+          ns_server = dns.getresource(zone_name, Resolv::DNS::Resource::IN::SOA).mname.to_s
+        rescue Resolv::ResolvError => e
+          abort "Domain doesn't exist"
+        end
+
+        case ns_server
+        when /dnsimple\.com\z/
+          'DNSimple'
+        when /dynect\.net\z/
+          'DynECT'
+        else
+          nil
+        end
       end
 
-      case ns_server
-      when /dnsimple\.com\z/
-        'DNSimple'
-      when /dynect\.net\z/
-        'DynECT'
-      else
-        nil
+      def record_types
+        Set.new([
+          'A',
+          'AAAA',
+          'ALIAS',
+          'CNAME',
+          'MX',
+          'NS',
+          'SPF',
+          'SRV',
+          'TXT',
+        ])
       end
-    end
 
-    def self.record_types
-      Set.new([
-        'A',
-        'AAAA',
-        'ALIAS',
-        'CNAME',
-        'MX',
-        'NS',
-        'SPF',
-        'SRV',
-        'TXT',
-      ])
-    end
-
-    def self.supports_alias?
-      false
+      def supports_alias?
+        false
+      end
     end
 
     def initialize(zone:)

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -38,7 +38,6 @@ module RecordStore
         false
       end
 
-      # TODO(es): ponder how you'll go to hell for this garbage code
       def build_zone(zone_name:, config:)
         zone = Zone.new(name: zone_name)
         zone.records = retrieve_current_records(zone: zone_name)
@@ -103,7 +102,7 @@ module RecordStore
       end
 
       def thawable?
-        self.respond_to?(:thaw)
+        self.respond_to?(:thaw_zone)
       end
 
       def freezable?

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -103,11 +103,11 @@ module RecordStore
       end
 
       def thawable?
-        self.class.method_defined?(:thaw)
+        self.respond_to?(:thaw)
       end
 
       def freezable?
-        self.class.method_defined?(:freeze_zone)
+        self.respond_to?(:freeze_zone)
       end
 
       def to_s

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -40,7 +40,7 @@ module RecordStore
 
       # TODO(es): ponder how you'll go to hell for this garbage code
       def build_zone(zone_name:, config:)
-        zone = Zone.new(zone_name)
+        zone = Zone.new(name: zone_name)
         zone.records = retrieve_current_records(zone: zone_name)
         zone.config = config
 

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -2,157 +2,163 @@ require 'fog/dnsimple'
 
 module RecordStore
   class Provider::DNSimple < Provider
-    def self.supports_alias?
-      true
-    end
-
-    def add(record)
-      record_hash = api_hash(record)
-      res = session.create_record(
-        @zone_name,
-        record_hash.fetch(:name),
-        record.type,
-        record_hash.fetch(:content),
-        ttl: record_hash.fetch(:ttl),
-        priority: record_hash.fetch(:prio, nil)
-      )
-
-      if record.type == 'ALIAS'
-        txt_alias = retrieve_current_records.detect do |rr|
-          rr.type == 'TXT' && rr.fqdn == record.fqdn && rr.txtdata == "ALIAS for #{record.alias.chomp('.')}"
-        end
-        remove(txt_alias)
+    class << self
+      def supports_alias?
+        true
       end
 
-      res
-    end
-
-    def remove(record)
-      session.delete_record(@zone_name, record.id)
-    end
-
-    def update(id, record)
-      record_hash = api_hash(record)
-      session.update_record(@zone_name, id, api_hash(record))
-    end
-
-    # returns an array of Record objects that match the records which exist in the provider
-    def retrieve_current_records(stdout = $stdout)
-      session.list_records(@zone_name).body.map do |record|
-        record_body = record.fetch('record')
-
-        begin
-          build_from_api(record_body)
-        rescue StandardError
-          stdout.puts "Cannot build record: #{record_body}"
-          raise
-        end
-      end.select(&:present?)
-    end
-
-    # Returns an array of the zones managed by provider as strings
-    def zones
-      session.zones.map(&:domain)
-    end
-
-    private
-
-    def discard_change_set
-      session.request(expects: 200, method: :delete, path: "ZoneChanges/#{@zone_name}")
-    end
-
-    def session
-      @dns ||= Fog::DNS.new(session_params)
-    end
-
-    def session_params
-      {
-        provider: 'DNSimple',
-        dnsimple_email: secrets.fetch('email'),
-        dnsimple_token: secrets.fetch('api_token'),
-      }
-    end
-
-    def secrets
-      super.fetch('dnsimple')
-    end
-
-    def build_from_api(api_record)
-      record_type = api_record.fetch('record_type')
-      record = {
-        record_id: api_record.fetch('id'),
-        ttl: api_record.fetch('ttl'),
-        fqdn: api_record.fetch('name').present? ? "#{api_record.fetch('name')}.#{@zone_name}" : @zone_name,
-      }
-
-      return if record_type == 'SOA'
-
-      case record_type
-      when 'A'
-        record.merge!(address: api_record.fetch('content'))
-      when 'AAAA'
-        record.merge!(address: api_record.fetch('content'))
-      when 'ALIAS'
-        record.merge!(alias: api_record.fetch('content'))
-      when 'CNAME'
-        record.merge!(cname: api_record.fetch('content'))
-      when 'MX'
-        record.merge!(preference: api_record.fetch('prio'), exchange: api_record.fetch('content'))
-      when 'NS'
-        record.merge!(nsdname: api_record.fetch('content'))
-      when 'SPF'
-        record.merge!(txtdata: api_record.fetch('content'))
-      when 'SRV'
-        weight, port, host = api_record.fetch('content').split(' ')
-
-        record.merge!(
-          priority: api_record.fetch('prio'),
-          weight: weight,
-          port: port,
-          target: Record.ensure_ends_with_dot(host),
+      def add(record, zone)
+        record_hash = api_hash(record, zone)
+        res = session.create_record(
+          zone,
+          record_hash.fetch(:name),
+          record.type,
+          record_hash.fetch(:content),
+          ttl: record_hash.fetch(:ttl),
+          priority: record_hash.fetch(:prio, nil)
         )
-      when 'TXT'
-        record.merge!(txtdata: api_record.fetch('content'))
+
+        if record.type == 'ALIAS'
+          txt_alias = retrieve_current_records(zone: zone).detect do |rr|
+            rr.type == 'TXT' && rr.fqdn == record.fqdn && rr.txtdata == "ALIAS for #{record.alias.chomp('.')}"
+          end
+          remove(txt_alias, zone)
+        end
+
+        res
       end
 
-      unless record.fetch(:fqdn).ends_with?('.')
-        record[:fqdn] += '.'
+      # TODO(es): ponder how you'll go to hell for this garbage code
+      def build_zone(zone_name:, config:)
+        zone = super(zone_name: (chomped_zone = zone_name.chomp('.')), config: config)
+        zone.name = chomped_zone
+
+        zone
       end
 
-      Record.const_get(record_type).new(record)
-    end
-
-    def api_hash(record)
-      record_hash = {
-        name: record.fqdn.gsub("#{Record.ensure_ends_with_dot(@zone_name)}", '').chomp('.'),
-        ttl: record.ttl,
-        type: record.type,
-      }
-
-      case record.type
-      when 'A'
-        record_hash[:content] = record.address
-      when 'AAAA'
-        record_hash[:content] = record.address
-      when 'ALIAS'
-        record_hash[:content] = record.alias.chomp('.')
-      when 'CNAME'
-        record_hash[:content] = record.cname.chomp('.')
-      when 'MX'
-        record_hash[:prio] = record.preference
-        record_hash[:content] = record.exchange.chomp('.')
-      when 'NS'
-        record_hash[:content] = record.nsdname.chomp('.')
-      when 'SPF'
-        record_hash[:content] = record.txtdata
-      when 'SRV'
-        record_hash[:content] = "#{record.weight} #{record.port} #{record.target.chomp('.')}"
-        record_hash[:prio] = record.priority
-      when 'TXT'
-        record_hash[:content] = record.txtdata
+      def remove(record, zone)
+        session.delete_record(zone, record.id)
       end
 
-      record_hash
+      def update(id, record, zone)
+        record_hash = api_hash(record, zone)
+        session.update_record(zone, id, api_hash(record, zone))
+      end
+
+      # returns an array of Record objects that match the records which exist in the provider
+      def retrieve_current_records(zone:, stdout: $stdout)
+        session.list_records(zone).body.map do |record|
+          record_body = record.fetch('record')
+
+          begin
+            build_from_api(record_body, zone)
+          rescue StandardError
+            stdout.puts "Cannot build record: #{record_body}"
+            raise
+          end
+        end.select(&:present?)
+      end
+
+      # Returns an array of the zones managed by provider as strings
+      def zones
+        session.zones.map(&:domain)
+      end
+
+      private
+
+      def session
+        @dns ||= Fog::DNS.new(session_params)
+      end
+
+      def session_params
+        {
+          provider: 'DNSimple',
+          dnsimple_email: secrets.fetch('email'),
+          dnsimple_token: secrets.fetch('api_token'),
+        }
+      end
+
+      def secrets
+        super.fetch('dnsimple')
+      end
+
+      def build_from_api(api_record, zone)
+        record_type = api_record.fetch('record_type')
+        record = {
+          record_id: api_record.fetch('id'),
+          ttl: api_record.fetch('ttl'),
+          fqdn: api_record.fetch('name').present? ? "#{api_record.fetch('name')}.#{zone}" : zone,
+        }
+
+        return if record_type == 'SOA'
+
+        case record_type
+        when 'A'
+          record.merge!(address: api_record.fetch('content'))
+        when 'AAAA'
+          record.merge!(address: api_record.fetch('content'))
+        when 'ALIAS'
+          record.merge!(alias: api_record.fetch('content'))
+        when 'CNAME'
+          record.merge!(cname: api_record.fetch('content'))
+        when 'MX'
+          record.merge!(preference: api_record.fetch('prio'), exchange: api_record.fetch('content'))
+        when 'NS'
+          record.merge!(nsdname: api_record.fetch('content'))
+        when 'SPF'
+          record.merge!(txtdata: api_record.fetch('content'))
+        when 'SRV'
+          weight, port, host = api_record.fetch('content').split(' ')
+
+          record.merge!(
+            priority: api_record.fetch('prio'),
+            weight: weight,
+            port: port,
+            target: Record.ensure_ends_with_dot(host),
+          )
+        when 'TXT'
+          record.merge!(txtdata: api_record.fetch('content'))
+        end
+
+        unless record.fetch(:fqdn).ends_with?('.')
+          record[:fqdn] += '.'
+        end
+
+        Record.const_get(record_type).new(record)
+      end
+
+      def api_hash(record, zone)
+        record_hash = {
+          name: record.fqdn.gsub("#{Record.ensure_ends_with_dot(zone)}", '').chomp('.'),
+          ttl: record.ttl,
+          type: record.type,
+        }
+
+        case record.type
+        when 'A'
+          record_hash[:content] = record.address
+        when 'AAAA'
+          record_hash[:content] = record.address
+        when 'ALIAS'
+          record_hash[:content] = record.alias.chomp('.')
+        when 'CNAME'
+          record_hash[:content] = record.cname.chomp('.')
+        when 'MX'
+          record_hash[:prio] = record.preference
+          record_hash[:content] = record.exchange.chomp('.')
+        when 'NS'
+          record_hash[:content] = record.nsdname.chomp('.')
+        when 'SPF'
+          record_hash[:content] = record.txtdata
+        when 'SRV'
+          record_hash[:content] = "#{record.weight} #{record.port} #{record.target.chomp('.')}"
+          record_hash[:prio] = record.priority
+        when 'TXT'
+          record_hash[:content] = record.txtdata
+        end
+
+        record_hash
+      end
     end
   end
 end

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -28,14 +28,6 @@ module RecordStore
         res
       end
 
-      # TODO(es): ponder how you'll go to hell for this garbage code
-      def build_zone(zone_name:, config:)
-        zone = super(zone_name: (chomped_zone = zone_name.chomp('.')), config: config)
-        zone.name = chomped_zone
-
-        zone
-      end
-
       def remove(record, zone)
         session.delete_record(zone, record.id)
       end

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -85,9 +85,7 @@ module RecordStore
         return if record_type == 'SOA'
 
         case record_type
-        when 'A'
-          record.merge!(address: api_record.fetch('content'))
-        when 'AAAA'
+        when 'A', 'AAAA'
           record.merge!(address: api_record.fetch('content'))
         when 'ALIAS'
           record.merge!(alias: api_record.fetch('content'))
@@ -97,7 +95,7 @@ module RecordStore
           record.merge!(preference: api_record.fetch('prio'), exchange: api_record.fetch('content'))
         when 'NS'
           record.merge!(nsdname: api_record.fetch('content'))
-        when 'SPF'
+        when 'SPF', 'TXT'
           record.merge!(txtdata: api_record.fetch('content'))
         when 'SRV'
           weight, port, host = api_record.fetch('content').split(' ')
@@ -108,8 +106,6 @@ module RecordStore
             port: port,
             target: Record.ensure_ends_with_dot(host),
           )
-        when 'TXT'
-          record.merge!(txtdata: api_record.fetch('content'))
         end
 
         unless record.fetch(:fqdn).ends_with?('.')
@@ -127,9 +123,7 @@ module RecordStore
         }
 
         case record.type
-        when 'A'
-          record_hash[:content] = record.address
-        when 'AAAA'
+        when 'A', 'AAAA'
           record_hash[:content] = record.address
         when 'ALIAS'
           record_hash[:content] = record.alias.chomp('.')
@@ -140,13 +134,11 @@ module RecordStore
           record_hash[:content] = record.exchange.chomp('.')
         when 'NS'
           record_hash[:content] = record.nsdname.chomp('.')
-        when 'SPF'
+        when 'SPF', 'TXT'
           record_hash[:content] = record.txtdata
         when 'SRV'
           record_hash[:content] = "#{record.weight} #{record.port} #{record.target.chomp('.')}"
           record_hash[:prio] = record.priority
-        when 'TXT'
-          record_hash[:content] = record.txtdata
         end
 
         record_hash

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -2,96 +2,98 @@ require 'fog/dynect'
 
 module RecordStore
   class Provider::DynECT < Provider
-    def freeze_zone
-      session.put_zone(@zone_name, freeze: true)
-    end
-
-    def thaw
-      session.put_zone(@zone_name, thaw: true)
-    end
-
-    def add(record)
-      session.post_record(record.type, @zone_name, record.fqdn, record.rdata, ttl: record.ttl)
-    end
-
-    def remove(record)
-      session.delete_record(record.type, @zone_name, record.fqdn, record.id)
-    end
-
-    def update(id, record)
-      session.put_record(record.type, @zone_name, record.fqdn, record.rdata, ttl: record.ttl, record_id: id)
-    end
-
-    def publish
-      session.put_zone(@zone_name, publish: true)
-    end
-
-    # Applies changeset to provider
-    def apply_changeset(changeset, stdout = $stdout)
-      begin
-        thaw
-        super
-        publish
-      rescue StandardError
-        puts "An exception occurred while applying DNS changes, deleting changeset"
-        discard_change_set
-        raise
-      ensure
-        freeze_zone
+    class << self
+      def freeze_zone(zone)
+        session.put_zone(zone, freeze: true)
       end
-    end
 
-    # returns an array of Record objects that match the records which exist in the provider
-    def retrieve_current_records(stdout = $stdout)
-      session.get_all_records(@zone_name).body.fetch('data').flat_map do |type, records|
-        records.map do |record_body|
-          begin
-            build_from_api(record_body)
-          rescue StandardError => e
-            stdout.puts "Cannot build record: #{record_body}"
-          end
+      def thaw(zone)
+        session.put_zone(zone, thaw: true)
+      end
+
+      def add(record, zone)
+        session.post_record(record.type, zone, record.fqdn, record.rdata, ttl: record.ttl)
+      end
+
+      def remove(record, zone)
+        session.delete_record(record.type, zone, record.fqdn, record.id)
+      end
+
+      def update(id, record, zone)
+        session.put_record(record.type, zone, record.fqdn, record.rdata, ttl: record.ttl, record_id: id)
+      end
+
+      def publish(zone)
+        session.put_zone(zone, publish: true)
+      end
+
+      # Applies changeset to provider
+      def apply_changeset(changeset, stdout = $stdout)
+        begin
+          thaw(changeset.zone)
+          super
+          publish(changeset.zone)
+        rescue StandardError
+          puts "An exception occurred while applying DNS changes, deleting changeset"
+          discard_change_set(changeset.zone)
+          raise
+        ensure
+          freeze_zone(changeset.zone)
         end
-      end.select(&:present?)
-    end
-
-    # Returns an array of the zones managed by provider as strings
-    def zones
-      session.zones.map(&:domain)
-    end
-
-    private
-
-    def discard_change_set
-      session.request(expects: 200, method: :delete, path: "ZoneChanges/#{@zone_name}")
-    end
-
-    def session
-      @dns ||= Fog::DNS.new(session_params)
-    end
-
-    def session_params
-      {
-        provider: 'Dynect',
-        dynect_customer: secrets.fetch('customer'),
-        dynect_username: secrets.fetch('username'),
-        dynect_password: secrets.fetch('password')
-      }
-    end
-
-    def secrets
-      super.fetch('dynect')
-    end
-
-    def build_from_api(api_record)
-      record = api_record.merge(api_record.fetch('rdata')).slice!('rdata').symbolize_keys
-
-      return if record.fetch(:record_type) == 'SOA'
-
-      unless record.fetch(:fqdn).ends_with?('.')
-        record[:fqdn] = "#{record.fetch(:fqdn)}."
       end
 
-      Record.const_get(record.fetch(:record_type)).new(record)
+      # returns an array of Record objects that match the records which exist in the provider
+      def retrieve_current_records(zone:, stdout: $stdout)
+        session.get_all_records(zone).body.fetch('data').flat_map do |type, records|
+          records.map do |record_body|
+            begin
+              build_from_api(record_body)
+            rescue StandardError => e
+              stdout.puts "Cannot build record: #{record_body}"
+            end
+          end
+        end.select(&:present?)
+      end
+
+      # Returns an array of the zones managed by provider as strings
+      def zones
+        session.zones.map(&:domain)
+      end
+
+      private
+
+      def discard_change_set(zone)
+        session.request(expects: 200, method: :delete, path: "ZoneChanges/#{zone}")
+      end
+
+      def session
+        @dns ||= Fog::DNS.new(session_params)
+      end
+
+      def session_params
+        {
+          provider: 'Dynect',
+          dynect_customer: secrets.fetch('customer'),
+          dynect_username: secrets.fetch('username'),
+          dynect_password: secrets.fetch('password')
+        }
+      end
+
+      def secrets
+        super.fetch('dynect')
+      end
+
+      def build_from_api(api_record)
+        record = api_record.merge(api_record.fetch('rdata')).slice!('rdata').symbolize_keys
+
+        return if record.fetch(:record_type) == 'SOA'
+
+        unless record.fetch(:fqdn).ends_with?('.')
+          record[:fqdn] = "#{record.fetch(:fqdn)}."
+        end
+
+        Record.const_get(record.fetch(:record_type)).new(record)
+      end
     end
   end
 end

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -7,7 +7,7 @@ module RecordStore
         session.put_zone(zone, freeze: true)
       end
 
-      def thaw(zone)
+      def thaw_zone(zone)
         session.put_zone(zone, thaw: true)
       end
 
@@ -30,7 +30,7 @@ module RecordStore
       # Applies changeset to provider
       def apply_changeset(changeset, stdout = $stdout)
         begin
-          thaw(changeset.zone)
+          thaw_zone(changeset.zone)
           super
           publish(changeset.zone)
         rescue StandardError

--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -19,6 +19,7 @@ module RecordStore
 
     def self.build_from_yaml_definition(yaml_definition)
       record_type = yaml_definition.fetch(:type)
+
       # TODO: remove backward compatibility support for ALIAS records using cname attribute instead of alias
       #       REMOVE after merging https://github.com/Shopify/record-store/pull/781
       case record_type

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -145,7 +145,6 @@ module RecordStore
       end
     end
 
-    # TODO(es): write test for one zone supporting, and another not
     def validate_provider_can_handle_zone_records
       record_types = records.map(&:type).to_set
       return unless config.valid?

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -21,7 +21,7 @@ module RecordStore
     class << self
       def download(name, provider_name, **write_options)
         # TODO(es): fix assumption of single provider
-        dns = new(name, config: {provider: provider_name}).provider
+        dns = new(name: name, config: {provider: provider_name}).provider
         current_records = dns.retrieve_current_records
         write(name, records: current_records, config: {
           provider: provider_name,
@@ -39,9 +39,10 @@ module RecordStore
       end
     end
 
-    def initialize(name, records: [], config: {})
+    def initialize(name:, records: [], config: {})
       @name = Record.ensure_ends_with_dot(name)
-      @config = RecordStore::Zone::Config.new(config)
+      config = config.inject({}){|h,(k,v)| h[k.to_sym] = v; h}
+      @config = RecordStore::Zone::Config.new(**config)
       @records = build_records(records)
     end
 

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -57,6 +57,10 @@ module RecordStore
       build_changesets.all?(&:empty?)
     end
 
+    def unrooted_name
+      @name.chomp('.')
+    end
+
     def records
       @records_cache ||= Zone.filter_records(@records, config.ignore_patterns)
     end
@@ -158,7 +162,7 @@ module RecordStore
       return if config.supports_alias?
 
       # TODO(es): refactor to specify which provider
-      errors.add(:records, "one of the providers for #{name.chomp('.')} does not support ALIAS records")
+      errors.add(:records, "one of the providers for #{unrooted_name} does not support ALIAS records")
     end
 
     def validate_alias_points_to_root

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -39,9 +39,9 @@ module RecordStore
     end
 
     def initialize(name, records: [], config: {})
-      @name            = Record.ensure_ends_with_dot(name)
-      @config          = RecordStore::Zone::Config.new(config)
-      @records         = build_records(records)
+      @name = Record.ensure_ends_with_dot(name)
+      @config = RecordStore::Zone::Config.new(config)
+      @records = build_records(records)
     end
 
     def changeset

--- a/lib/record_store/zone/config.rb
+++ b/lib/record_store/zone/config.rb
@@ -22,10 +22,13 @@ module RecordStore
       end
 
       def to_hash
-        {
+        config_hash = {
           providers: providers,
           ignore_patterns: ignore_patterns,
         }
+        config_hash.merge!(supports_alias: supports_alias) if supports_alias
+
+        config_hash
       end
 
       private

--- a/lib/record_store/zone/config.rb
+++ b/lib/record_store/zone/config.rb
@@ -38,7 +38,7 @@ module RecordStore
       end
 
       def valid_providers?
-        providers.all? { |provider| Provider.constants.include?(provider.to_s.to_sym) }
+        providers.present? && providers.all? { |provider| Provider.constants.include?(provider.to_s.to_sym) }
       end
     end
   end

--- a/lib/record_store/zone/config.rb
+++ b/lib/record_store/zone/config.rb
@@ -18,7 +18,7 @@ module RecordStore
       # TODO(es): Test for one provider supporting ALIAS and another not
       def supports_alias?
         if @supports_alias.nil?
-          valid_providers? && providers.map { |provider| Provider.const_get(provider).supports_alias? }.all?
+          valid_providers? && providers.all? { |provider| Provider.const_get(provider).supports_alias? }
         else
           @supports_alias
         end
@@ -38,7 +38,7 @@ module RecordStore
       end
 
       def valid_providers?
-        providers.map { |provider| Provider.constants.include?(provider.to_s.to_sym) }.all?
+        providers.all? { |provider| Provider.constants.include?(provider.to_s.to_sym) }
       end
     end
   end

--- a/lib/record_store/zone/config.rb
+++ b/lib/record_store/zone/config.rb
@@ -7,15 +7,12 @@ module RecordStore
 
       validate :validate_zone_config
 
-      # TODO(es): delete provider when doing major version bump
       def initialize(ignore_patterns: [], providers: nil, supports_alias: nil)
         @ignore_patterns = ignore_patterns
         @providers = providers
         @supports_alias = supports_alias
       end
 
-
-      # TODO(es): Test for one provider supporting ALIAS and another not
       def supports_alias?
         if @supports_alias.nil?
           valid_providers? && providers.all? { |provider| Provider.const_get(provider).supports_alias? }

--- a/lib/record_store/zone/config.rb
+++ b/lib/record_store/zone/config.rb
@@ -3,23 +3,30 @@ module RecordStore
     class Config
       include ActiveModel::Validations
 
-      attr_reader :ignore_patterns, :provider, :supports_alias
+      attr_reader :ignore_patterns, :providers, :supports_alias
 
       validate :validate_zone_config
 
-      def initialize(ignore_patterns: [], provider: nil, supports_alias: nil)
+      # TODO(es): delete provider when doing major version bump
+      def initialize(ignore_patterns: [], providers: nil, supports_alias: nil)
         @ignore_patterns = ignore_patterns
-        @provider = provider
+        @providers = providers
         @supports_alias = supports_alias
       end
 
+
+      # TODO(es): Test for one provider supporting ALIAS and another not
       def supports_alias?
-        @supports_alias.nil? && valid_provider? ? Provider.const_get(provider).supports_alias? : @supports_alias
+        if @supports_alias.nil?
+          valid_providers? && providers.map { |provider| Provider.const_get(provider).supports_alias? }.all?
+        else
+          @supports_alias
+        end
       end
 
       def to_hash
         {
-          provider: provider,
+          providers: providers,
           ignore_patterns: ignore_patterns,
         }
       end
@@ -27,11 +34,11 @@ module RecordStore
       private
 
       def validate_zone_config
-        errors.add(:provider, 'provider specified does not exist') unless valid_provider?
+        errors.add(:providers, 'provider specified does not exist') unless valid_providers?
       end
 
-      def valid_provider?
-        Provider.constants.include?(provider.to_s.to_sym)
+      def valid_providers?
+        providers.map { |provider| Provider.constants.include?(provider.to_s.to_sym) }.all?
       end
     end
   end

--- a/lib/record_store/zone/yaml_definitions.rb
+++ b/lib/record_store/zone/yaml_definitions.rb
@@ -61,7 +61,7 @@ module RecordStore
         raise 'more than one zone in file' if data.size > 1
         name, definition = data.first
         definition['records'] ||= []
-        definition['records'] = definition['records'].map {|hash| hash.inject({}){|h,(k,v)| h[k.to_sym] = v; h}}
+        definition['records'] = definition['records'].map(&:deep_symbolize_keys)
         Dir["#{dir}/#{name}/*__*.yml"].each do |record_file|
           definition['records'] += load_yml_record_definitions(name, record_file)
         end
@@ -72,9 +72,7 @@ module RecordStore
         type, domain = File.basename(record_file, '.yml').split('__')
         Array.wrap(YAML.load_file(record_file)).map do |record_definition|
           record_definition.merge('fqdn' => "#{domain}.#{name}", 'type' => type)
-        end.map do |hash|
-          hash.inject({}){|h,(k,v)| h[k.to_sym] = v; h}
-        end
+        end.map(&:deep_symbolize_keys)
       end
 
       def remove_record_files(name)

--- a/lib/record_store/zone/yaml_definitions.rb
+++ b/lib/record_store/zone/yaml_definitions.rb
@@ -10,7 +10,7 @@ module RecordStore
       def defined
         @defined ||= yaml_files
           .map { |file| load_yml_zone_definition(file) }
-          .index_by { |zone| zone.name.chomp('.') }
+          .index_by { |zone| zone.unrooted_name }
       end
 
       def [](name)

--- a/test/changeset_test.rb
+++ b/test/changeset_test.rb
@@ -173,8 +173,6 @@ class ChangesetTest < Minitest::Test
 
     # Cassette matches zone's records except with an additional ALIAS record
     VCR.use_cassette 'dynect_retrieve_current_records' do
-      # TODO(es): fix bullshit chomp
-      zone.name = zone.name.chomp('.')
       changeset = Changeset.build_from(provider: zone.providers[0], zone: zone)
 
       assert_equal 1, changeset.removals.length

--- a/test/changeset_test.rb
+++ b/test/changeset_test.rb
@@ -6,12 +6,16 @@ class ChangesetTest < Minitest::Test
     @cname_record_copy = Record::CNAME.new(fqdn: 'www.example.com', ttl: 60, cname: 'www.example.org')
     @a_record = Record::A.new(fqdn: 'www.example.com', ttl: 60, address: '10.11.12.13')
     @a_record_copy = Record::A.new(fqdn: 'www.example.com', ttl: 60, address: '10.11.12.13')
+    @provider = RecordStore::Provider::DNSimple
+    @zone = 'dns-test.shopify.io'
   end
 
   def test_additions
     cs = Changeset.new(
       current_records: [],
-      desired_records: [@cname_record, @a_record]
+      desired_records: [@cname_record, @a_record],
+      provider: @provider,
+      zone: @zone,
     )
 
     assert cs.changes.all? { |c| c.is_a?(Changeset::Change) }
@@ -25,7 +29,9 @@ class ChangesetTest < Minitest::Test
   def test_removals
     cs = Changeset.new(
       current_records: [@cname_record, @a_record].each{|rr| rr.id = rand(1..100)},
-      desired_records: []
+      desired_records: [],
+      provider: @provider,
+      zone: @zone,
     )
 
     assert cs.changes.all? { |c| c.is_a?(Changeset::Change) }
@@ -39,7 +45,9 @@ class ChangesetTest < Minitest::Test
   def test_no_changes
     cs = Changeset.new(
       current_records: [@cname_record, @a_record].each{|rr| rr.id = rand(1..100)},
-      desired_records: [@cname_record_copy, @a_record_copy]
+      desired_records: [@cname_record_copy, @a_record_copy],
+      provider: @provider,
+      zone: @zone,
     )
 
     assert_equal 0, cs.changes.length
@@ -53,7 +61,9 @@ class ChangesetTest < Minitest::Test
   def test_removal_and_addition
     cs = Changeset.new(
       current_records: [@cname_record].each{|rr| rr.id = rand(1..100)},
-      desired_records: [@a_record]
+      desired_records: [@a_record],
+      provider: @provider,
+      zone: @zone,
     )
 
     assert_equal 2, cs.changes.length
@@ -70,7 +80,9 @@ class ChangesetTest < Minitest::Test
 
     cs = Changeset.new(
       current_records: [@cname_record].each{|rr| rr.id = rand(1..100)},
-      desired_records: [@cname_record_copy]
+      desired_records: [@cname_record_copy],
+      provider: @provider,
+      zone: @zone,
     )
 
     assert_equal 1, cs.changes.length
@@ -86,7 +98,9 @@ class ChangesetTest < Minitest::Test
 
     cs = Changeset.new(
       current_records: [@a_record, a_record_dup].each{|rr| rr.id = rand(1..100)},
-      desired_records: [@a_record_copy]
+      desired_records: [@a_record_copy],
+      provider: @provider,
+      zone: @zone,
     )
 
     assert_equal 2, cs.changes.length
@@ -102,7 +116,9 @@ class ChangesetTest < Minitest::Test
 
     cs = Changeset.new(
       current_records: [@a_record].each{|rr| rr.id = rand(1..100)},
-      desired_records: [@a_record_copy, a_record_dup]
+      desired_records: [@a_record_copy, a_record_dup],
+      provider: @provider,
+      zone: @zone,
     )
 
     assert_equal 2, cs.changes.length
@@ -114,7 +130,9 @@ class ChangesetTest < Minitest::Test
   def test_additions_removals_and_changes_are_enumerable
     cs = Changeset.new(
       current_records: [@cname_record].each{|rr| rr.id = rand(1..100)},
-      desired_records: [@cname_record_copy]
+      desired_records: [@cname_record_copy],
+      provider: @provider,
+      zone: @zone,
     )
 
     assert_kind_of Enumerable, cs.additions

--- a/test/dummy/config.yml
+++ b/test/dummy/config.yml
@@ -3,3 +3,4 @@ zones_path: zones/
 zones:
   - empty.com
   - one-record.com
+  - two-providers.com

--- a/test/dummy/zones/empty.com.yml
+++ b/test/dummy/zones/empty.com.yml
@@ -1,4 +1,5 @@
 empty.com:
   config:
-    provider: DynECT
+    providers:
+      - DynECT
   records: []

--- a/test/dummy/zones/merged-records.com.yml
+++ b/test/dummy/zones/merged-records.com.yml
@@ -1,6 +1,7 @@
 merged-records.com:
   config:
-    provider: DynECT
+    providers:
+      - DynECT
   records:
   - type: A
     fqdn: a-record.merged-records.com.

--- a/test/dummy/zones/one-record.com.yml
+++ b/test/dummy/zones/one-record.com.yml
@@ -1,6 +1,7 @@
 one-record.com:
   config:
-    provider: DynECT
+    providers:
+    - DynECT
     ignore_patterns:
     - type: NS
       fqdn: one-record.com.

--- a/test/dummy/zones/two-providers.com.yml
+++ b/test/dummy/zones/two-providers.com.yml
@@ -1,0 +1,8 @@
+two-providers.com:
+  config:
+    providers:
+    - DynECT
+    - DNSimple
+    ignore_patterns:
+    - type: NS
+      fqdn: one-record.com.

--- a/test/dummy/zones/two-records.com.yml
+++ b/test/dummy/zones/two-records.com.yml
@@ -1,6 +1,7 @@
 two-records.com:
   config:
-    provider: DynECT
+    providers:
+      - DynECT
     ignore_patterns:
       - type: NS
         fqdn: two-records.com.

--- a/test/dummy/zones/zone-file.com.yml
+++ b/test/dummy/zones/zone-file.com.yml
@@ -1,6 +1,7 @@
 zone-file.com:
   config:
-    provider: DynECT
+    providers:
+    - DynECT
     ignore_patterns:
     - type: NS
       fqdn: zone-file.com.

--- a/test/providers/dnsimple_test.rb
+++ b/test/providers/dnsimple_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class DNSimpleTest < Minitest::Test
   def setup
     @zone_name = 'dns-scratch.me'
-    @dnsimple = Provider::DNSimple.new(zone: @zone_name)
+    @dnsimple = Provider::DNSimple
   end
 
   def test_supports_alias_by_default
@@ -23,7 +23,7 @@ class DNSimpleTest < Minitest::Test
       "system_record" => false,
       "created_at" => "2015-12-11T16:30:17.380Z",
       "updated_at" => "2015-12-11T16:30:17.380Z"
-    })
+    }, @zone_name)
 
     assert_kind_of Record::A, record
     assert_equal 'a.dns-scratch.me.', record.fqdn
@@ -44,7 +44,7 @@ class DNSimpleTest < Minitest::Test
       "system_record" => false,
       "created_at" => "2015-12-11T16:30:29.630Z",
       "updated_at" => "2015-12-11T16:30:29.630Z"
-    })
+    }, @zone_name)
 
     assert_kind_of Record::AAAA, record
     assert_equal 'aaaa.dns-scratch.me.', record.fqdn
@@ -65,7 +65,7 @@ class DNSimpleTest < Minitest::Test
       "system_record" => false,
       "created_at" => "2015-12-10T19:56:21.366Z",
       "updated_at" => "2015-12-10T19:56:21.366Z"
-    })
+    }, @zone_name)
 
     assert_kind_of Record::ALIAS, record
     assert_equal 'dns-scratch.me.', record.fqdn
@@ -86,7 +86,7 @@ class DNSimpleTest < Minitest::Test
       "system_record" => false,
       "created_at" => "2015-12-11T16:30:41.284Z",
       "updated_at" => "2015-12-11T16:30:41.284Z"
-    })
+    }, @zone_name)
 
     assert_kind_of Record::CNAME, record
     assert_equal 'cname.dns-scratch.me.', record.fqdn
@@ -107,7 +107,7 @@ class DNSimpleTest < Minitest::Test
       "system_record" => false,
       "created_at" => "2015-12-10T19:58:20.474Z",
       "updated_at" => "2015-12-11T16:31:06.956Z"
-    })
+    }, @zone_name)
 
     assert_kind_of Record::MX, record
     assert_equal 'mx.dns-scratch.me.', record.fqdn
@@ -129,7 +129,7 @@ class DNSimpleTest < Minitest::Test
       "system_record" => true,
       "created_at" => "2015-12-09T01:55:04.792Z",
       "updated_at" => "2015-12-09T01:55:04.792Z"
-    })
+    }, @zone_name)
 
     assert_kind_of Record::NS, record
     assert_equal 'dns-scratch.me.', record.fqdn
@@ -150,7 +150,7 @@ class DNSimpleTest < Minitest::Test
       "system_record" => false,
       "created_at" => "2015-12-11T16:33:10.947Z",
       "updated_at" => "2015-12-11T16:33:10.947Z"
-    })
+    }, @zone_name)
 
     assert_kind_of Record::SRV, record
     assert_equal '_service._TCP.srv.dns-scratch.me.', record.fqdn
@@ -174,7 +174,7 @@ class DNSimpleTest < Minitest::Test
       "system_record" => true,
       "created_at" => "2013-02-19T22:58:25.148Z",
       "updated_at" => "2013-02-19T22:58:38.751Z"
-    })
+    }, @zone_name)
 
     assert_nil record
   end
@@ -192,7 +192,7 @@ class DNSimpleTest < Minitest::Test
       "system_record" => false,
       "created_at" => "2015-12-11T16:36:26.504Z",
       "updated_at" => "2015-12-11T16:36:26.504Z"
-    })
+    }, @zone_name)
 
     assert_kind_of Record::TXT, record
     assert_equal 'txt.dns-scratch.me.', record.fqdn
@@ -206,7 +206,9 @@ class DNSimpleTest < Minitest::Test
     VCR.use_cassette 'dnsimple_apply_changeset' do
       @dnsimple.apply_changeset(Changeset.new(
         current_records: [],
-        desired_records: [a_record]
+        desired_records: [a_record],
+        provider: RecordStore::Provider::DNSimple,
+        zone: @zone_name
       ))
     end
   end
@@ -217,10 +219,12 @@ class DNSimpleTest < Minitest::Test
     VCR.use_cassette 'dnsimple_apply_changeset_with_alias' do
       @dnsimple.apply_changeset(Changeset.new(
         current_records: [],
-        desired_records: [alias_record]
+        desired_records: [alias_record],
+        provider: RecordStore::Provider::DNSimple,
+        zone: @zone_name
       ))
 
-      records = @dnsimple.retrieve_current_records
+      records = @dnsimple.retrieve_current_records(zone: @zone_name)
       refute_includes records.map(&:type), 'TXT'
       assert_includes records.map(&:type), 'ALIAS'
     end
@@ -273,7 +277,7 @@ class DNSimpleTest < Minitest::Test
     ]
 
     VCR.use_cassette 'dnsimple_retrieve_current_records' do
-      records = @dnsimple.retrieve_current_records
+      records = @dnsimple.retrieve_current_records(zone: @zone_name)
       assert_equal records_arr, records
     end
   end

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -5,10 +5,6 @@ class DynECTTest < Minitest::Test
     @zone_name = 'dns-test.shopify.io'
   end
 
-  def teardown
-    Provider::DynECT.instance_variable_set(:@dns, nil)
-  end
-
   def test_supports_alias_by_default
     refute_predicate Provider::DynECT, :supports_alias?
   end

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -3,7 +3,10 @@ require 'test_helper'
 class DynECTTest < Minitest::Test
   def setup
     @zone_name = 'dns-test.shopify.io'
-    @dyn = Provider::DynECT
+  end
+
+  def teardown
+    Provider::DynECT.instance_variable_set(:@dns, nil)
   end
 
   def test_supports_alias_by_default
@@ -11,7 +14,7 @@ class DynECTTest < Minitest::Test
   end
 
   def test_build_a_from_api
-    record = @dyn.send(:build_from_api, {
+    record = Provider::DynECT.send(:build_from_api, {
       'zone' => 'dns-test.shopify.io',
       'fqdn' => 'test.dns-test.shopify.io',
       'record_type' => 'A',
@@ -28,7 +31,7 @@ class DynECTTest < Minitest::Test
   end
 
   def test_build_aaaa_from_api
-    record = @dyn.send(:build_from_api, {
+    record = Provider::DynECT.send(:build_from_api, {
       "zone" => "dns-test.shopify.io",
       "ttl" => 60,
       "fqdn" => "aaaa.dns-test.shopify.io",
@@ -54,7 +57,7 @@ class DynECTTest < Minitest::Test
         'alias' => 'dns-test.herokuapp.com.',
       },
     }
-    record = @dyn.send(:build_from_api, api_record)
+    record = Provider::DynECT.send(:build_from_api, api_record)
 
     assert_kind_of Record::ALIAS, record
     assert_equal 'dns-test.shopify.io.', record.fqdn
@@ -63,7 +66,7 @@ class DynECTTest < Minitest::Test
   end
 
   def test_build_cname_from_api
-    record = @dyn.send(:build_from_api, {
+    record = Provider::DynECT.send(:build_from_api, {
       "zone" => "dns-test.shopify.io",
       "ttl" => 60,
       "fqdn" => "cname.dns-test.shopify.io",
@@ -80,7 +83,7 @@ class DynECTTest < Minitest::Test
   end
 
   def test_build_mx_from_api
-    record = @dyn.send(:build_from_api, {
+    record = Provider::DynECT.send(:build_from_api, {
       "zone" => "dns-test.shopify.io",
       "ttl" => 60,
       "fqdn" => "mx.dns-test.shopify.io",
@@ -99,7 +102,7 @@ class DynECTTest < Minitest::Test
   end
 
   def test_build_ns_from_api
-    record = @dyn.send(:build_from_api, {
+    record = Provider::DynECT.send(:build_from_api, {
       "zone" => "dns-test.shopify.io",
       "ttl" => 3600,
       "fqdn" => "dns-test.shopify.io",
@@ -116,7 +119,7 @@ class DynECTTest < Minitest::Test
   end
 
   def test_build_srv_from_api
-    record = @dyn.send(:build_from_api, {
+    record = Provider::DynECT.send(:build_from_api, {
       "zone" => "dns-test.shopify.io",
       "ttl" => 60,
       "fqdn" => "_service._TCP.srv.dns-test.shopify.io",
@@ -139,7 +142,7 @@ class DynECTTest < Minitest::Test
   end
 
   def test_build_soa_from_api
-    record = @dyn.send(:build_from_api, {
+    record = Provider::DynECT.send(:build_from_api, {
       "zone" => "dns-test.shopify.io",
       "ttl" => 3600,
       "fqdn" => "dns-test.shopify.io",
@@ -160,7 +163,7 @@ class DynECTTest < Minitest::Test
   end
 
   def test_build_txt_from_api
-    record = @dyn.send(:build_from_api, {
+    record = Provider::DynECT.send(:build_from_api, {
       "zone" => "dns-test.shopify.io",
       "ttl" => 60,
       "fqdn" => "txt.dns-test.shopify.io",
@@ -180,7 +183,7 @@ class DynECTTest < Minitest::Test
     a_record = Record::A.new(fqdn: 'test-record.dns-test.shopify.io.', ttl: 86400, address: '10.10.10.42')
 
     VCR.use_cassette 'dynect_apply_changeset' do
-      @dyn.apply_changeset(Changeset.new(
+      Provider::DynECT.apply_changeset(Changeset.new(
         current_records: [],
         desired_records: [a_record],
         provider: RecordStore::Provider::DynECT,
@@ -236,23 +239,22 @@ class DynECTTest < Minitest::Test
     ]
 
     VCR.use_cassette 'dynect_retrieve_current_records' do
-      records = @dyn.retrieve_current_records(zone: @zone_name)
+      records = Provider::DynECT.retrieve_current_records(zone: @zone_name)
       assert_equal records_arr, records
     end
   end
 
   def test_zones_returns_list_of_zones_managed_by_provider
     VCR.use_cassette 'dynect_zones' do
-      assert_equal @dyn.zones, [@zone_name]
+      assert_equal Provider::DynECT.zones, [@zone_name]
     end
   end
 
   def test_dynect_is_thawable
-    binding.pry
-    assert_predicate @dyn, :thawable?
+    assert_predicate Provider::DynECT, :thawable?
   end
 
   def test_dynect_is_freezable
-    assert_predicate @dyn, :freezable?
+    assert_predicate Provider::DynECT, :freezable?
   end
 end

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class DynECTTest < Minitest::Test
   def setup
     @zone_name = 'dns-test.shopify.io'
-    @dyn = Provider::DynECT.new(zone: @zone_name)
+    @dyn = Provider::DynECT
   end
 
   def test_supports_alias_by_default
@@ -182,7 +182,9 @@ class DynECTTest < Minitest::Test
     VCR.use_cassette 'dynect_apply_changeset' do
       @dyn.apply_changeset(Changeset.new(
         current_records: [],
-        desired_records: [a_record]
+        desired_records: [a_record],
+        provider: RecordStore::Provider::DynECT,
+        zone: @zone_name
       ))
     end
   end
@@ -234,7 +236,7 @@ class DynECTTest < Minitest::Test
     ]
 
     VCR.use_cassette 'dynect_retrieve_current_records' do
-      records = @dyn.retrieve_current_records
+      records = @dyn.retrieve_current_records(zone: @zone_name)
       assert_equal records_arr, records
     end
   end
@@ -246,6 +248,7 @@ class DynECTTest < Minitest::Test
   end
 
   def test_dynect_is_thawable
+    binding.pry
     assert_predicate @dyn, :thawable?
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,11 @@ class Minitest::Test
 
   RecordStore.config_path = DUMMY_CONFIG_PATH
 
+  def teardown
+    Provider::DynECT.instance_variable_set(:@dns, nil)
+    Provider::DNSimple.instance_variable_set(:@dns, nil)
+  end
+
   VCR.configure do |config|
     config.cassette_library_dir = "test/fixtures/vcr_cassettes"
     config.hook_into :excon

--- a/test/zone/config_test.rb
+++ b/test/zone/config_test.rb
@@ -45,4 +45,9 @@ example.com:
     config = Zone.new(name: 'dnsimple-config.com', config: {providers: ['DNSimple']}).config
     assert_predicate config, :supports_alias?
   end
+
+  def test_config_does_not_supports_alias_when_multiple_providers_disagree
+    config = Zone.new(name: 'dnsimple-config.com', config: {providers: ['DNSimple', 'DynECT']}).config
+    refute_predicate config, :supports_alias?
+  end
 end

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -302,6 +302,7 @@ class ZoneTest < Minitest::Test
   def test_zone_provider_returns_instantiated_zone_provider
     zone = Zone.find('one-record.com')
     assert_respond_to zone, :provider
+    # TODO(es): fix assumption of single provider
     assert_instance_of Provider::DynECT, zone.provider
   end
 

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -6,10 +6,6 @@ class ZoneTest < Minitest::Test
     Zone.reset
   end
 
-  def teardown
-    Provider::DynECT.instance_variable_set(:@dns, nil)
-  end
-
   def test_find_returns_zone_by_name
     zone = Zone.find('one-record.com')
 

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class ZoneTest < Minitest::Test
   def setup
-    @provider = [RecordStore::Provider::DNSimple, RecordStore::Provider::DynECT].sample
     Zone.reset
   end
 

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -14,7 +14,6 @@ class ZoneTest < Minitest::Test
   end
 
   def test_find_returns_zone_by_name_in_single_file
-    binding.pry
     zone = Zone.find('zone-file.com')
 
     assert_instance_of Zone, zone
@@ -66,7 +65,7 @@ class ZoneTest < Minitest::Test
 
   def test_zone_is_not_valid_unless_config_is
     zone = Zone.find('empty.com')
-    zone.config = build_config(provider: 'BadProvider')
+    zone.config = build_config(providers: ['BadProvider'])
 
     refute_predicate zone, :valid?
   end
@@ -343,7 +342,7 @@ class ZoneTest < Minitest::Test
 
   def test_zone_write_format_dir_writes_wildcard
     with_zones_tmpdir do
-      zone = Zone.new('wildcard.com', records: [{
+      zone = Zone.new(name: 'wildcard.com', records: [{
         type: 'CNAME',
         fqdn: '*.wildcard.com',
         cname: 'wildcard.com',
@@ -359,7 +358,7 @@ class ZoneTest < Minitest::Test
 
   def test_zone_write_format_dir_writes_multiple_records
     with_zones_tmpdir do
-      zone = Zone.new('two-records.com', records: [{
+      zone = Zone.new(name: 'two-records.com', records: [{
         type: 'A',
         fqdn: 'a-records.two-records.com',
         address: "10.10.10.10",
@@ -380,14 +379,14 @@ class ZoneTest < Minitest::Test
   end
 
   def test_zone_validates_matching_ttls_for_records_with_same_type_and_fqdn
-    valid_zone = Zone.new('matching-records.com', config: { provider: 'DynECT' }, records: [
+    valid_zone = Zone.new(name: 'matching-records.com', config: { providers: ['DynECT'] }, records: [
       { type: 'TXT', fqdn: 'matching-records.com', txtdata: "unicorn", ttl: 60 },
       { type: 'TXT', fqdn: 'matching-records.com', txtdata: "walrus",  ttl: 60 },
     ])
 
     assert_predicate valid_zone, :valid?
 
-    invalid_zone = Zone.new('matching-records.com', config: { provider: 'DynECT' }, records: [
+    invalid_zone = Zone.new(name: 'matching-records.com', config: { providers: ['DynECT'] }, records: [
       { type: 'TXT', fqdn: 'matching-records.com', txtdata: "unicorn", ttl: 60 },
       { type: 'TXT', fqdn: 'matching-records.com', txtdata: "walrus",  ttl: 3600 },
     ])
@@ -397,12 +396,12 @@ class ZoneTest < Minitest::Test
   end
 
   def test_zone_validates_support_for_alias_records
-    valid_zone = Zone.new('matching-records.com', config: { provider: 'DynECT', supports_alias: true }, records: [
+    valid_zone = Zone.new(name: 'matching-records.com', config: { providers: ['DynECT'], supports_alias: true }, records: [
       { type: 'ALIAS', fqdn: 'matching-records.com', alias: 'matching-records.herokuapp.com', ttl: 60 },
     ])
     assert_predicate valid_zone, :valid?
 
-    invalid_zone = Zone.new('matching-records.com', config: { provider: 'DynECT' }, records: [
+    invalid_zone = Zone.new(name: 'matching-records.com', config: { providers: ['DynECT'] }, records: [
       { type: 'ALIAS', fqdn: 'matching-records.com', alias: 'matching-records.herokuapp.com', ttl: 60 },
     ])
     refute_predicate invalid_zone, :valid?
@@ -410,12 +409,12 @@ class ZoneTest < Minitest::Test
   end
 
   def test_zone_validates_alias_points_to_root
-    valid_zone = Zone.new('matching-records.com', config: { provider: 'DynECT', supports_alias: true }, records: [
+    valid_zone = Zone.new(name: 'matching-records.com', config: { providers: ['DynECT'], supports_alias: true }, records: [
       { type: 'ALIAS', fqdn: 'matching-records.com', alias: 'matching-records.herokuapp.com', ttl: 60 },
     ])
     assert_predicate valid_zone, :valid?
 
-    invalid_zone = Zone.new('matching-records.com', config: { provider: 'DynECT', supports_alias: true }, records: [
+    invalid_zone = Zone.new(name: 'matching-records.com', config: { providers: ['DynECT'], supports_alias: true }, records: [
       { type: 'ALIAS', fqdn: 'alias.matching-records.com', alias: 'matching-records.herokuapp.com', ttl: 60 },
     ])
     refute_predicate invalid_zone, :valid?
@@ -432,12 +431,12 @@ class ZoneTest < Minitest::Test
   end
 
   def valid_zone_from_records(name, records:)
-    Zone.new(name, records: records, config: {provider: 'DynECT'})
+    Zone.new(name: name, records: records, config: {providers: ['DynECT']})
   end
 
   def build_config(args)
     default_args = {
-      provider: 'DynECT',
+      providers: ['DynECT'],
       ignore_patterns: []
     }
 

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class ZoneTest < Minitest::Test
   def setup
+    @provider = [RecordStore::Provider::DNSimple, RecordStore::Provider::DynECT].sample
     Zone.reset
   end
 
@@ -13,6 +14,7 @@ class ZoneTest < Minitest::Test
   end
 
   def test_find_returns_zone_by_name_in_single_file
+    binding.pry
     zone = Zone.find('zone-file.com')
 
     assert_instance_of Zone, zone

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -372,6 +372,20 @@ class ZoneTest < Minitest::Test
     assert_equal 'ALIAS record should be defined on the root of the zone: [ALIASRecord] alias.matching-records.com. 60 IN ALIAS matching-records.herokuapp.com.', invalid_zone.errors[:records].first
   end
 
+  def test_modified_returns_all_zones_with_changes
+    zone_a = Zone.find('one-record.com')
+    zone_a.stubs(:build_changesets).returns([populated_changeset])
+
+    zone_b = Zone.find('two-providers.com')
+    zone_b.stubs(:build_changesets).returns([empty_changeset])
+
+    Zone.stubs(:all).returns([zone_a, zone_b])
+
+    modified_zones = Zone.modified
+    assert_equal 1, modified_zones.length
+    assert_equal zone_a, modified_zones[0]
+  end
+
   private
 
   def valid_zone_from_records(name, records:)


### PR DESCRIPTION
For: https://github.com/Shopify/service-disruptions/issues/530, https://github.com/Shopify/traffic/issues/998, https://github.com/Shopify/traffic/issues/169 

**Problem**:
Record Store currently only supports a single provider. This requires us to manually change the provider of every single zone and deploy.

**Solution**:
By deploying to multiple providers at all times, we can have a zone's NS records point to more than one (lowering the impact of a DNS provider outage). This PR adds the ability to specify multiple providers for a single zone. 

Before a zone would specify:
```
provider: DynECT
```

Now the config *must* be changed to an array format:
```
providers:
  - DynECT
```

To have the zone synced to multiple providers at the same time, simply specify an additional provider in the array:
```
providers:
  - DynECT
  - DNSimple
```


**How?**
The main change was disassociating providers from individual zones. Now providers are static classes. Changesets have been modified to be provider specific. They have a static method to create a changeset between a zone and a specific provider. Calling `Changeset#apply` will apply the `Change`s of the changeset to synchronize the state. `Zone#build_changesets` will build a changeset for every provider of a zone.


Paired with @klautcomputing 

r: @wvanbergen @etiennebarrie @sbfaulkner @andrewlouis93 @marc-barry @camilo 