### PR TITLE
Fix DNSimple treating SRV attributes as strings

### DIFF
--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -101,9 +101,9 @@ module RecordStore
           weight, port, host = api_record.fetch('content').split(' ')
 
           record.merge!(
-            priority: api_record.fetch('prio'),
-            weight: weight,
-            port: port,
+            priority: api_record.fetch('prio').to_i,
+            weight: weight.to_i,
+            port: port.to_i,
             target: Record.ensure_ends_with_dot(host),
           )
         end

--- a/test/providers/dnsimple_test.rb
+++ b/test/providers/dnsimple_test.rb
@@ -155,8 +155,8 @@ class DNSimpleTest < Minitest::Test
     assert_kind_of Record::SRV, record
     assert_equal '_service._TCP.srv.dns-scratch.me.', record.fqdn
     assert_equal 10, record.priority
-    assert_equal '47', record.weight
-    assert_equal '80', record.port
+    assert_equal 47, record.weight
+    assert_equal 80, record.port
     assert_equal 'target-srv.dns-scratch.me.', record.target
     assert_equal 60, record.ttl
   end


### PR DESCRIPTION
Related: https://github.com/Shopify/record-store/issues/876

r: @klautcomputing @marc-barry