### PR TITLE
TTL updates apply to same record

### DIFF
--- a/lib/record_store/changeset.rb
+++ b/lib/record_store/changeset.rb
@@ -76,8 +76,8 @@ module RecordStore
     private
 
     def build_changeset
-      current_records_set = (current_records - unchanged).group_by(&:key)
-      desired_records_set = (desired_records - unchanged).group_by(&:key)
+      current_records_set = (current_records - unchanged).sort_by(&:to_s).group_by(&:key)
+      desired_records_set = (desired_records - unchanged).sort_by(&:to_s).group_by(&:key)
       current_records_set.default_proc = desired_records_set.default_proc = Proc.new{Array.new}
 
       record_keys = current_records_set.keys | desired_records_set.keys

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -33,7 +33,6 @@ module RecordStore
       end
 
       def update(id, record, zone)
-        record_hash = api_hash(record, zone)
         session.update_record(zone, id, api_hash(record, zone))
       end
 

--- a/template/zones/dnsimple.example.com.yml
+++ b/template/zones/dnsimple.example.com.yml
@@ -1,6 +1,7 @@
 dnsimple.example.com:
   config:
-    provider: DNSimple
+    providers:
+      - DNSimple
     ignore_patterns:
     - type: NS
       fqdn: dnsimple.example.com.

--- a/template/zones/dynect.example.com.yml
+++ b/template/zones/dynect.example.com.yml
@@ -1,6 +1,7 @@
 dynect.example.com:
   config:
-    provider: DynECT
+    providers:
+      - DynECT
     ignore_patterns:
     - type: NS
       fqdn: dynect.example.com.


### PR DESCRIPTION
**Problem**:
When generating the changeset, record store lines up the desired and current records in 2 arrays (for every `{type, fqdn}`) and zips them. This gives us an array of pairs (current record and desired record). If the order of records changes, it's possible to generate updates that'll create duplicate records inflight. 

**Example**:
Suppose you have record `A` and `B` with matching FQDNs, different content, but matching TTLs. The change is to modify the TTL of both records, but we've also re-arranged them in record store.


Provider (aka current records): `[A_current, B_current]`
Record Store (aka desired records): `[B_desired, A_desired]`

The changeset produced will have the record id of `A_current` update to match `B_desired`. As the updates are applied, record store will attempt to update `A_current` to `B_desired`. This operation is invalid as you can't have multiple records with matching `{type, fqdn, rdata}` tuples in a zone (keep in mind `B_current` is still in its original state).

**Solution**:
Sorting the records before the diff is generated is good enough to match up records with the same content.


r: @marc-barry @klautcomputing @stonith @dwradcliffe 