### PR TITLE
Mimic DNSimple's behaviour around escaping semicolons

### DIFF
--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -95,7 +95,7 @@ module RecordStore
         when 'NS'
           record.merge!(nsdname: api_record.fetch('content'))
         when 'SPF', 'TXT'
-          record.merge!(txtdata: api_record.fetch('content'))
+          record.merge!(txtdata: api_record.fetch('content').gsub(';', '\;'))
         when 'SRV'
           weight, port, host = api_record.fetch('content').split(' ')
 
@@ -134,7 +134,7 @@ module RecordStore
         when 'NS'
           record_hash[:content] = record.nsdname.chomp('.')
         when 'SPF', 'TXT'
-          record_hash[:content] = record.txtdata
+          record_hash[:content] = record.txtdata.gsub('\;', ';')
         when 'SRV'
           record_hash[:content] = "#{record.weight} #{record.port} #{record.target.chomp('.')}"
           record_hash[:prio] = record.priority

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '3.1.3'
+  VERSION = '3.1.4'
 end


### PR DESCRIPTION
**Problem**
DNSimple escapes semicolons even if they're already escaped. It then also esacpes the slash that's escaping the semicolon.

**Solution**
This remove the slash escaping the semicolon before we update the records in DNSimple. It'll also automatically escape any semicolons when reading the API to keep records in sync properly.

r: @dwradcliffe @stonith