### PR TITLE
Return exit status 1 on failure

### DIFF
--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -8,6 +8,10 @@ module RecordStore
       RecordStore.config_path = options.fetch('config', "#{Dir.pwd}/config.yml")
     end
 
+    def self.exit_on_failure?
+      true
+    end
+
     desc 'thaw', 'Thaws all zones under management to allow manual edits'
     def thaw
       Zone.each do |_, zone|

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -31,4 +31,13 @@ class CLITest < Minitest::Test
   ensure
     ENV['EJSON_KEYDIR'] = ejson_keydir
   end
+
+  def test_returns_nonzero_exit_status
+    stderr = STDERR.clone
+    STDERR.reopen(File::NULL, "w")
+    Thor.expects(:exit).with(1)
+    RecordStore::CLI.start(%w(does not exist))
+  ensure
+    STDERR.reopen(stderr)
+  end
 end


### PR DESCRIPTION
When we removed `record-store validate_all_present`, our CI continued to have this as a step and it didn't cause failures.
This made me realize Thor doesn't return a non-zero exit status when the command is unknown.
https://github.com/erikhuda/thor/issues/244#issuecomment-11116989

This probably breaks compatibility in a way, but I think it's fine. Should I ship a 4.1.0 with that?

@es @dwradcliffe 