### PR TITLE
Check for circular references in CNAME

### DIFF
--- a/lib/record_store/record/alias.rb
+++ b/lib/record_store/record/alias.rb
@@ -3,6 +3,7 @@ module RecordStore
     attr_accessor :alias
 
     validates :alias, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
+    validate :validate_circular_reference
 
     def initialize(record)
       super
@@ -15,6 +16,10 @@ module RecordStore
 
     def to_s
       "[ALIASRecord] #{fqdn} #{ttl} IN ALIAS #{self.alias}"
+    end
+
+    def validate_circular_reference
+      errors.add(:fqdn, 'An ALIAS should not point to itself') unless fqdn != @alias
     end
   end
 end

--- a/lib/record_store/record/cname.rb
+++ b/lib/record_store/record/cname.rb
@@ -3,6 +3,7 @@ module RecordStore
     attr_accessor :cname
 
     validates :cname, presence: true, format: { with: Record::CNAME_REGEX, message: 'is not a fully qualified domain name' }
+    validate :validate_circular_reference
 
     def initialize(record)
       super
@@ -15,6 +16,10 @@ module RecordStore
 
     def to_s
       "[CNAMERecord] #{fqdn} #{ttl} IN CNAME #{cname}"
+    end
+
+    def validate_circular_reference
+      errors.add(:fqdn, 'A CNAME should not point to itself') unless fqdn != cname
     end
   end
 end

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '4.0.0'
+  VERSION = '4.0.1'.freeze
 end

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -49,7 +49,13 @@ class RecordTest < Minitest::Test
   end
 
   def test_validates_cname
-    refute Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: 'example.com').valid?
+    assert Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: 'example2.com').valid?
+    refute Record::CNAME.new(fqdn: 'samedomain.com', ttl: 3600, cname: 'samedomain.com').valid?
+  end
+
+  def test_validates_alias
+    assert Record::ALIAS.new(fqdn: 'example.com', ttl: 3600, alias: 'example2.com').valid?
+    refute Record::ALIAS.new(fqdn: 'samedomain.com', ttl: 3600, alias: 'samedomain.com').valid?
   end
 
   def test_to_hash

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -48,6 +48,10 @@ class RecordTest < Minitest::Test
     refute Record::A.new(fqdn: 'example.com.', ttl: 2 ** 32, address: '10.11.12.13').valid?
   end
 
+  def test_validates_cname
+    refute Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: 'example.com').valid?
+  end
+
   def test_to_hash
     record = Record::NS.new(fqdn: 'example.com', ttl: 600, nsdname: 'blah.example.com')
     hash = record.to_hash


### PR DESCRIPTION
Recently, https://github.com/Shopify/record-store/pull/1271 failed to deploy because of CNAME circular reference.

This PR will validate that this does not happen again.