### PR TITLE
bump up job polling timeout for fog-dynect

### DIFF
--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -76,7 +76,7 @@ module RecordStore
           dynect_customer: secrets.fetch('customer'),
           dynect_username: secrets.fetch('username'),
           dynect_password: secrets.fetch('password'),
-          job_poll_timeout: 20,
+          job_poll_timeout: 20
         }
       end
 

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -75,7 +75,8 @@ module RecordStore
           provider: 'Dynect',
           dynect_customer: secrets.fetch('customer'),
           dynect_username: secrets.fetch('username'),
-          dynect_password: secrets.fetch('password')
+          dynect_password: secrets.fetch('password'),
+          job_poll_timeout: 20,
         }
       end
 


### PR DESCRIPTION
We recently started to see errors such as 
```
/app/data/bundler/ruby/2.3.0/gems/fog-dynect-0.1.0/lib/fog/dynect/dns.rb:144:in `rescue in poll_job': Job 3822483214 is still incomplete (Fog::DNS::Dynect::JobIncomplete)
	from /app/data/bundler/ruby/2.3.0/gems/fog-dynect-0.1.0/lib/fog/dynect/dns.rb:131:in `poll_job'
	from /app/data/bundler/ruby/2.3.0/gems/fog-dynect-0.1.0/lib/fog/dynect/dns.rb:105:in `request'
```
during deploy. I suspect this is because now we have more entries in Dyn it takes more time for the job to finish in under 10 minutes(default polling timeout). The PR doubles the timeout.

@Shopify/traffic 