### PR TITLE
Support double hyphen (--) in CNAME

### DIFF
--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -1,7 +1,7 @@
 module RecordStore
   class Record
     FQDN_REGEX  = /\A(\*\.)?([a-z0-9_]+(-[a-z0-9]+)*\._?)+[a-z]{2,}\.\Z/i
-    CNAME_REGEX =  /\A(\*\.)?([a-z0-9]+(-[a-z0-9]+)*\._?)+[a-z]{2,}\.\Z/i
+    CNAME_REGEX =  /\A(\*\.)?([a-z0-9]+((-|--)?[a-z0-9]+)*\._?)+[a-z]{2,}\.\Z/i
 
     include ActiveModel::Validations
 

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -50,7 +50,11 @@ class RecordTest < Minitest::Test
 
   def test_validates_cname
     assert Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: 'example2.com').valid?
+    assert Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: 'example-2.com').valid?
+    assert Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: 'example--2.com').valid?
     refute Record::CNAME.new(fqdn: 'samedomain.com', ttl: 3600, cname: 'samedomain.com').valid?
+    refute Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: 'example---2.com').valid?
+    refute Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: '--2.com').valid?
   end
 
   def test_validates_alias


### PR DESCRIPTION
Names such as `website--name.com` are valid domain names according to [this](https://stackoverflow.com/questions/16468309/can-domain-name-have-two-continuous-hyphens) but our CNAME_REGEX doesn't allow them. This PR permits said domain names.