### PR TITLE
require 'resolv' to fix uninitialized constant

### DIFF
--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -1,3 +1,5 @@
+require 'resolv'
+
 module RecordStore
   class Provider
     class << self

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '4.0.3'.freeze
+  VERSION = '4.0.4'.freeze
 end


### PR DESCRIPTION
not sure why this has not previously been an issue, but this PR fixes this...

```
$ dev add_zone mruby.science
/Users/sbfaulkner/.gem/ruby/2.3.1/gems/record_store-4.0.3/lib/record_store/provider.rb:5:in `provider_for': uninitialized constant #<Class:RecordStore::Provider>::Resolv (NameError)
	from /Users/sbfaulkner/.gem/ruby/2.3.1/gems/record_store-4.0.3/lib/record_store/cli.rb:125:in `download'
	from /Users/sbfaulkner/.gem/ruby/2.3.1/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	from /Users/sbfaulkner/.gem/ruby/2.3.1/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/sbfaulkner/.gem/ruby/2.3.1/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
	from /Users/sbfaulkner/.gem/ruby/2.3.1/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
	from /Users/sbfaulkner/src/github.com/Shopify/record-store/bin/record-store:6:in `<main>'
```