### PR TITLE
fix updates of records with same fqdn

### DIFF
--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -12,7 +12,7 @@ module RecordStore
       end
 
       def add(record, zone)
-        session.post_record(record.type, zone, record.fqdn, record.rdata, ttl: record.ttl)
+        session.post_record(record.type, zone, record.fqdn, record.rdata, 'ttl' => record.ttl)
       end
 
       def remove(record, zone)
@@ -20,7 +20,7 @@ module RecordStore
       end
 
       def update(id, record, zone)
-        session.put_record(record.type, zone, record.fqdn, record.rdata, ttl: record.ttl, record_id: id)
+        session.put_record(record.type, zone, record.fqdn, record.rdata, 'ttl' => record.ttl, 'record_id' => id)
       end
 
       def publish(zone)

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '4.0.6'.freeze
+  VERSION = '4.0.7'.freeze
 end

--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'fog'
   spec.add_runtime_dependency 'fog-json'
   spec.add_runtime_dependency 'fog-xml'
-  spec.add_runtime_dependency 'fog-dynect', '~> 0.1.0'
+  spec.add_runtime_dependency 'fog-dynect', '~> 0.2.0'
   spec.add_runtime_dependency 'ejson'
 
   spec.add_development_dependency 'rake'

--- a/test/fixtures/vcr_cassettes/dynect_apply_changeset_update.yml
+++ b/test/fixtures/vcr_cassettes/dynect_apply_changeset_update.yml
@@ -1,0 +1,180 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-v4.dynect.net/REST/Session
+    body:
+      encoding: UTF-8
+      string: '{"customer_name":"dynect_customer","user_name":"<DYNECT_USERNAME>","password":"<DYNECT_PASSWORD>"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Content-Type:
+      - application/json
+      API-Version:
+      - 3.5.2
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      Server:
+      - nginx/1.2.6
+      Date:
+      - Fri, 06 Nov 2015 20:01:07 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "success", "data": {"token": "<DYNECT_AUTH_TOKEN>", "version":
+        "3.5.2"}, "job_id": 1974045841, "msgs": [{"INFO": "login: Login successful",
+        "SOURCE": "BLL", "ERR_CD": null, "LVL": "INFO"}]}'
+    http_version:
+  recorded_at: Fri, 06 Nov 2015 20:01:07 GMT
+- request:
+    method: put
+    uri: https://api-v4.dynect.net/REST/Zone/dns-test.shopify.io
+    body:
+      encoding: UTF-8
+      string: '{"thaw":true}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Content-Type:
+      - application/json
+      API-Version:
+      - 3.5.2
+      Auth-Token:
+      - "<DYNECT_AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      Server:
+      - nginx/1.2.6
+      Date:
+      - Fri, 06 Nov 2015 20:01:08 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "success", "data": {}, "job_id": 1974045863, "msgs": [{"INFO":
+        "thaw: Your zone is now thawed, you may edit normally", "SOURCE": "BLL", "ERR_CD":
+        null, "LVL": "INFO"}]}'
+    http_version:
+  recorded_at: Fri, 06 Nov 2015 20:01:08 GMT
+- request:
+    method: put
+    uri: https://api-v4.dynect.net/REST/TXTRecord/dns-test.shopify.io/test-record.dns-test.shopify.io./12345678
+    body:
+      encoding: UTF-8
+      string: '{"ttl":3600,"rdata":{"txtdata":"update"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Content-Type:
+      - application/json
+      API-Version:
+      - 3.5.2
+      Auth-Token:
+      - "<DYNECT_AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      Server:
+      - nginx/1.2.6
+      Date:
+      - Fri, 06 Nov 2015 20:01:09 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "success", "data": {"zone": "dns-test.shopify.io", "ttl":
+        3600, "fqdn": "test-record.dns-test.shopify.io.", "record_type": "TXT", "rdata":
+        {"txtdata": "update"}, "record_id": 0}, "job_id": 1974045894, "msgs":
+        [{"INFO": "update: Record updated", "SOURCE": "BLL", "ERR_CD": null,
+        "LVL": "INFO"}]}'
+    http_version:
+  recorded_at: Fri, 06 Nov 2015 20:01:09 GMT
+- request:
+    method: put
+    uri: https://api-v4.dynect.net/REST/Zone/dns-test.shopify.io
+    body:
+      encoding: UTF-8
+      string: '{"publish":true}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Content-Type:
+      - application/json
+      API-Version:
+      - 3.5.2
+      Auth-Token:
+      - "<DYNECT_AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      Server:
+      - nginx/1.2.6
+      Date:
+      - Fri, 06 Nov 2015 20:01:10 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "success", "data": {"zone_type": "Primary", "serial_style":
+        "increment", "serial": 29, "zone": "dns-test.shopify.io"}, "job_id": 1974045926,
+        "msgs": [{"INFO": "notes: unnecessary field passed in", "SOURCE": "API-A",
+        "ERR_CD": "INVALID_DATA", "LVL": "WARN"}, {"INFO": "publish: dns-test.shopify.io
+        published", "SOURCE": "BLL", "ERR_CD": null, "LVL": "INFO"}]}'
+    http_version:
+  recorded_at: Fri, 06 Nov 2015 20:01:10 GMT
+- request:
+    method: put
+    uri: https://api-v4.dynect.net/REST/Zone/dns-test.shopify.io
+    body:
+      encoding: UTF-8
+      string: '{"freeze":true}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Content-Type:
+      - application/json
+      API-Version:
+      - 3.5.2
+      Auth-Token:
+      - "<DYNECT_AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      Server:
+      - nginx/1.2.6
+      Date:
+      - Fri, 06 Nov 2015 20:01:11 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "success", "data": {}, "job_id": 1974045941, "msgs": [{"INFO":
+        "freeze: Your zone is now frozen", "SOURCE": "BLL", "ERR_CD": null, "LVL":
+        "INFO"}]}'
+    http_version:
+  recorded_at: Fri, 06 Nov 2015 20:01:11 GMT
+recorded_with: VCR 2.9.3

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -240,6 +240,21 @@ class DynECTTest < Minitest::Test
     end
   end
 
+  def test_apply_changeset_updates_specific_record
+    txt_1 = Record::TXT.new(record_id: 12345678, fqdn: 'test-record.dns-test.shopify.io.', ttl: 3600, txtdata: "one")
+    txt_2 = Record::TXT.new(record_id: 99999999, fqdn: 'test-record.dns-test.shopify.io.', ttl: 3600, txtdata: "two")
+    txt_update = Record::TXT.new(fqdn: 'test-record.dns-test.shopify.io.', ttl: 3600, txtdata: "update")
+
+    VCR.use_cassette 'dynect_apply_changeset_update' do
+      Provider::DynECT.apply_changeset(Changeset.new(
+        current_records: [txt_1, txt_2],
+        desired_records: [txt_update, txt_2],
+        provider: RecordStore::Provider::DynECT,
+        zone: @zone_name
+      ))
+    end
+  end
+
   def test_zones_returns_list_of_zones_managed_by_provider
     VCR.use_cassette 'dynect_zones' do
       assert_equal Provider::DynECT.zones, [@zone_name]


### PR DESCRIPTION
this PR fixes #39

fog-dynect expects string keys for options hash (https://github.com/fog/fog-dynect/blob/master/lib/fog/dynect/requests/dns/put_record.rb#L19)

record_store was passing symbols (https://github.com/Shopify/record_store/pull/41/files#diff-f3285f7dfe4728480bd7d479256b9608L23)

this fixes that (and includes a test that verifies we actually update a specific record)
  
  