### PR TITLE
Switch to fog-dnsimple and API v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'fog'
 gem 'fog-json'
 gem 'fog-xml'
 gem 'fog-dynect', '~> 0.2.0'
+gem 'fog-dnsimple', '~> 2.0.0'
 gem 'google-cloud-dns'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,9 @@ GEM
       builder
       excon (~> 0.49)
       formatador (~> 0.2)
+    fog-dnsimple (2.0.0)
+      fog-core (>= 1.38, < 3)
+      fog-json (~> 1.0)
     fog-dynect (0.2.0)
       fog-core
       fog-json
@@ -207,6 +210,7 @@ DEPENDENCIES
   activesupport (~> 4.2)
   ejson
   fog
+  fog-dnsimple (~> 2.0.0)
   fog-dynect (~> 0.2.0)
   fog-json
   fog-xml

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -64,8 +64,8 @@ module RecordStore
       def session_params
         {
           provider: 'DNSimple',
-          dnsimple_email: secrets.fetch('email'),
           dnsimple_token: secrets.fetch('api_token'),
+          dnsimple_account: secrets.fetch('account_id'),
         }
       end
 

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -15,7 +15,7 @@ module RecordStore
           record.type,
           record_hash.fetch(:content),
           ttl: record_hash.fetch(:ttl),
-          priority: record_hash.fetch(:prio, nil)
+          priority: record_hash.fetch(:priority, nil)
         )
 
         if record.type == 'ALIAS'
@@ -74,7 +74,7 @@ module RecordStore
       end
 
       def build_from_api(api_record, zone)
-        record_type = api_record.fetch('record_type')
+        record_type = api_record.fetch('type')
         record = {
           record_id: api_record.fetch('id'),
           ttl: api_record.fetch('ttl'),
@@ -91,7 +91,7 @@ module RecordStore
         when 'CNAME'
           record.merge!(cname: api_record.fetch('content'))
         when 'MX'
-          record.merge!(preference: api_record.fetch('prio'), exchange: api_record.fetch('content'))
+          record.merge!(preference: api_record.fetch('priority'), exchange: api_record.fetch('content'))
         when 'NS'
           record.merge!(nsdname: api_record.fetch('content'))
         when 'SPF', 'TXT'
@@ -100,7 +100,7 @@ module RecordStore
           weight, port, host = api_record.fetch('content').split(' ')
 
           record.merge!(
-            priority: api_record.fetch('prio').to_i,
+            priority: api_record.fetch('priority').to_i,
             weight: weight.to_i,
             port: port.to_i,
             target: Record.ensure_ends_with_dot(host),
@@ -129,7 +129,7 @@ module RecordStore
         when 'CNAME'
           record_hash[:content] = record.cname.chomp('.')
         when 'MX'
-          record_hash[:prio] = record.preference
+          record_hash[:priority] = record.preference
           record_hash[:content] = record.exchange.chomp('.')
         when 'NS'
           record_hash[:content] = record.nsdname.chomp('.')
@@ -137,7 +137,7 @@ module RecordStore
           record_hash[:content] = record.txtdata.gsub('\;', ';')
         when 'SRV'
           record_hash[:content] = "#{record.weight} #{record.port} #{record.target.chomp('.')}"
-          record_hash[:prio] = record.priority
+          record_hash[:priority] = record.priority
         end
 
         record_hash

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -38,9 +38,7 @@ module RecordStore
 
       # returns an array of Record objects that match the records which exist in the provider
       def retrieve_current_records(zone:, stdout: $stdout)
-        session.list_records(zone).body.map do |record|
-          record_body = record.fetch('record')
-
+        session.list_records(zone).body["data"].map do |record_body|
           begin
             build_from_api(record_body, zone)
           rescue StandardError

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '4.0.7'.freeze
+  VERSION = '5.0.0'.freeze
 end

--- a/template/secrets.json
+++ b/template/secrets.json
@@ -5,7 +5,7 @@
     "password": "dynect_password"
   },
   "dnsimple": {
-    "email": "dnsimple_email",
+    "account_id": "dnsimple_email",
     "api_token": "dnsimple_api_token"
   },
   "google_cloud_dns": {

--- a/test/dummy/secrets.json
+++ b/test/dummy/secrets.json
@@ -5,11 +5,11 @@
     "password": "dynect_password"
   },
   "dnsimple": {
-    "email": "dnsimple_email",
+    "account_id": "dnsimple_account_id",
     "api_token": "dnsimple_api_token"
   },
   "google_cloud_dns": {
-    "type": "type",
+    "type": "service_account",
     "project_id": "project_id",
     "private_key_id": "private_key_id",
     "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIICWgIBAAKBgGsd4RrLAgGKI3cRmywv1FXoAzNG3pgh1X/xjeDu5Fnjr8bvDGog\nctx9iyr5p7NbazgAQxaBWXAgr9p0jjkWzSaTCNskSuk/jJwwn4VQbfXKkyNNaIuc\nk2xn++JJ7Dv4+ODJupP3+A1QUH/uzsGi7xGGNzkC1ojSZlT40OxDrP1VAgMBAAEC\ngYA0xQ2Gg4hDdegu2m+VfyKeB6S7+CfkzpY9Z6S7sTSxy+dmm5GEHuQ3F2oeC8vA\nIkNZ3VcvmR2UjaXUeyMtoLwDpmboRPm3SEtITReSBQGLTeeFymJwIPks0VXckOTh\nrhbyK7StiJ/0jWNtted0vBPEjEAuP6tyURpbVGIBQ1V+aQJBALv6sWWZOKVVThNc\nOGpnBAzTWGQMgp9nD+7rwbAbzRD3hvW5ln6O94a0XPWg9WD++gHDVr9OU7Ooe63O\n/0qw3EcCQQCR4IyjUqYzBZWyD+EKugNtc8VAOrJsYIE+gkajiikjV4nbj8CVg/CO\nunLrkDGAHTgzfY2tTyI6gQt2ctbfFRODAkB8Kl5tBqVVCCDXRu340mzpb9yN0Xmi\ngvgST+WTRvnQQEAEJX9Tv2mer5pLoPMUC7fl3Dp7iOhe3mY7a2RT2LjXAkAVNUg9\nFm8DS/SPhq95F8IXz5UF2YLHLuCbbeVHMXb5pGhue1/MXPpERecfSD9qGNVq5v4K\nDE81oj1AY0HJ/Q5xAkAYOrEnGeJSjLhvJYfMJOAjf39pJs0Kh/2C7HySaILNWt3f\nK590FbFkwBw+bmylpnOxa2jJpzt7F3gGIast6on3\n-----END RSA PRIVATE KEY-----",

--- a/test/fixtures/vcr_cassettes/dnsimple_apply_changeset.yml
+++ b/test/fixtures/vcr_cassettes/dnsimple_apply_changeset.yml
@@ -2,15 +2,15 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.dnsimple.com/v1/domains/dns-scratch.me/records
+    uri: https://api.dnsimple.com/v2/<DNSIMPLE_ACCOUNT_ID>/zones/dns-scratch.me/records
     body:
       encoding: UTF-8
-      string: '{"record":{"name":"test-record","record_type":"A","content":"10.10.10.42","ttl":86400,"priority":null}}'
+      string: '{"name":"test-record","type":"A","content":"10.10.10.42","ttl":86400,"priority":null}'
     headers:
       User-Agent:
-      - fog-core/1.32.1
-      X-DNSimple-Token:
-      - "<DNSIMPLE_EMAIL>:<DNSIMPLE_API_TOKEN>"
+      - fog-core/1.44.3 fog-dnsimple/2.0.0
+      Authorization:
+      - "<DNSIMPLE_AUTH_TOKEN>"
       Accept:
       - application/json
       Content-Type:
@@ -18,47 +18,45 @@ http_interactions:
   response:
     status:
       code: 201
-      message: 
+      message: Created
     headers:
       Server:
       - nginx
       Date:
-      - Mon, 14 Dec 2015 23:59:43 GMT
+      - Wed, 24 Jan 2018 20:46:05 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631138519, max-age=31536000
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with
-      Access-Control-Allow-Methods:
-      - GET,POST,PUT,DELETE,OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN, DENY
-      X-XSS-Protection:
-      - '1'
-      X-Content-Type-Options:
-      - nosniff, nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      ETag:
-      - W/"e43529baa4f39253403e4ea5eeea11b3"
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2381'
+      X-Ratelimit-Reset:
+      - '1516829520'
+      Etag:
+      - W/"d704e0bdf73eac718a0c883df6c284a3"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 90b38e52-5ec1-4af6-b7d1-f858b0b8c766
+      - 3e809729-4d87-4fc4-9bc6-0c082445d87e
       X-Runtime:
-      - '0.077761'
+      - '0.054776'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
     body:
-      encoding: UTF-8
-      string: '{"record":{"id":5207716,"domain_id":222002,"parent_id":null,"name":"test-record","content":"10.10.10.42","ttl":86400,"prio":null,"record_type":"A","system_record":false,"created_at":"2015-12-14T23:59:43.036Z","updated_at":"2015-12-14T23:59:43.036Z"}}'
-    http_version: 
-  recorded_at: Mon, 14 Dec 2015 23:59:43 GMT
-recorded_with: VCR 2.9.3
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":13343292,"zone_id":"dns-scratch.me","parent_id":null,"name":"test-record","content":"10.10.10.42","ttl":86400,"priority":null,"type":"A","regions":["global"],"system_record":false,"created_at":"2018-01-24T20:46:05Z","updated_at":"2018-01-24T20:46:05Z"}}'
+    http_version:
+  recorded_at: Wed, 24 Jan 2018 20:46:05 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/dnsimple_apply_changeset_with_alias.yml
+++ b/test/fixtures/vcr_cassettes/dnsimple_apply_changeset_with_alias.yml
@@ -2,15 +2,15 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.dnsimple.com/v1/domains/dns-scratch.me/records
+    uri: https://api.dnsimple.com/v2/<DNSIMPLE_ACCOUNT_ID>/zones/dns-scratch.me/records
     body:
       encoding: UTF-8
-      string: '{"record":{"name":"","record_type":"ALIAS","content":"dns-scratch.herokuapp.com","ttl":86400,"priority":null}}'
+      string: '{"name":"","type":"ALIAS","content":"dns-scratch.herokuapp.com","ttl":86400,"priority":null}'
     headers:
       User-Agent:
-      - fog-core/1.32.1
-      X-DNSimple-Token:
-      - "<DNSIMPLE_EMAIL>:<DNSIMPLE_API_TOKEN>"
+      - fog-core/1.44.3 fog-dnsimple/2.0.0
+      Authorization:
+      - "<DNSIMPLE_AUTH_TOKEN>"
       Accept:
       - application/json
       Content-Type:
@@ -18,60 +18,58 @@ http_interactions:
   response:
     status:
       code: 201
-      message:
+      message: Created
     headers:
       Server:
       - nginx
       Date:
-      - Tue, 15 Dec 2015 16:52:51 GMT
+      - Wed, 24 Jan 2018 20:44:33 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
-      Status:
-      - 201 Created
-      Strict-Transport-Security:
-      - max-age=631138519, max-age=31536000
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with
-      Access-Control-Allow-Methods:
-      - GET,POST,PUT,DELETE,OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN, DENY
-      X-XSS-Protection:
-      - '1'
-      X-Content-Type-Options:
-      - nosniff, nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      ETag:
-      - W/"9bc6a79740b1eb8015dda23b44ac930b"
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2385'
+      X-Ratelimit-Reset:
+      - '1516829520'
+      Etag:
+      - W/"8067b699d9498d94df7d32f7d5673297"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - b726866b-3802-4963-ac96-4177b6632a20
+      - 023c4c88-6ee8-4e33-9993-e8f8eaf4fde6
       X-Runtime:
-      - '0.516040'
+      - '0.078524'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
     body:
-      encoding: UTF-8
-      string: '{"record":{"id":5209959,"domain_id":222002,"parent_id":null,"name":"","content":"dns-scratch.herokuapp.com","ttl":86400,"prio":null,"record_type":"ALIAS","system_record":false,"created_at":"2015-12-15T16:52:50.970Z","updated_at":"2015-12-15T16:52:50.970Z"}}'
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":13343287,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"dns-scratch.herokuapp.com","ttl":86400,"priority":null,"type":"ALIAS","regions":["global"],"system_record":false,"created_at":"2018-01-24T20:44:33Z","updated_at":"2018-01-24T20:44:33Z"}}'
     http_version:
-  recorded_at: Tue, 15 Dec 2015 16:52:51 GMT
+  recorded_at: Wed, 24 Jan 2018 20:44:33 GMT
 - request:
     method: get
-    uri: https://api.dnsimple.com/v1/domains/dns-scratch.me/records
+    uri: https://api.dnsimple.com/v2/<DNSIMPLE_ACCOUNT_ID>/zones/dns-scratch.me/records
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.32.1
-      X-DNSimple-Token:
-      - "<DNSIMPLE_EMAIL>:<DNSIMPLE_API_TOKEN>"
+      - fog-core/1.44.3 fog-dnsimple/2.0.0
+      Authorization:
+      - "<DNSIMPLE_AUTH_TOKEN>"
       Accept:
       - application/json
       Content-Type:
@@ -79,123 +77,115 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: OK
     headers:
       Server:
       - nginx
       Date:
-      - Tue, 15 Dec 2015 16:52:51 GMT
+      - Wed, 24 Jan 2018 20:44:33 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631138519, max-age=31536000
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with
-      Access-Control-Allow-Methods:
-      - GET,POST,PUT,DELETE,OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN, DENY
-      X-XSS-Protection:
-      - '1'
-      X-Content-Type-Options:
-      - nosniff, nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      ETag:
-      - W/"7db04136cdab1bf934bb582c0d8898d5"
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2384'
+      X-Ratelimit-Reset:
+      - '1516829520'
+      Etag:
+      - W/"b88be14d56b86e1007a120082cfc959b"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 19ea3e10-bba4-4b46-989a-fb7a9526790c
+      - 40c2b993-10d0-4e8a-a71a-58836f98fedb
       X-Runtime:
-      - '0.034068'
+      - '0.032550'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
     body:
-      encoding: UTF-8
-      string: '[{"record":{"id":5207716,"domain_id":222002,"parent_id":null,"name":"test-record","content":"10.10.10.42","ttl":86400,"prio":null,"record_type":"A","system_record":false,"created_at":"2015-12-14T23:59:43.036Z","updated_at":"2015-12-14T23:59:43.036Z"}},{"record":{"id":5209959,"domain_id":222002,"parent_id":null,"name":"","content":"dns-scratch.herokuapp.com","ttl":86400,"prio":null,"record_type":"ALIAS","system_record":false,"created_at":"2015-12-15T16:52:50.970Z","updated_at":"2015-12-15T16:52:50.970Z"}},{"record":{"id":5190382,"domain_id":222002,"parent_id":null,"name":"","content":"ns1.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:04.792Z","updated_at":"2015-12-09T01:55:04.792Z"}},{"record":{"id":5190385,"domain_id":222002,"parent_id":null,"name":"","content":"ns4.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:05.250Z","updated_at":"2015-12-09T01:55:05.250Z"}},{"record":{"id":5190384,"domain_id":222002,"parent_id":null,"name":"","content":"ns3.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:05.111Z","updated_at":"2015-12-09T01:55:05.111Z"}},{"record":{"id":5190383,"domain_id":222002,"parent_id":null,"name":"","content":"ns2.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:04.938Z","updated_at":"2015-12-09T01:55:04.938Z"}},{"record":{"id":5190381,"domain_id":222002,"parent_id":null,"name":"","content":"ns1.dnsimple.com
-        admin.dnsimple.com 1449626156 86400 7200 604800 300","ttl":3600,"prio":null,"record_type":"SOA","system_record":true,"created_at":"2015-12-09T01:55:04.067Z","updated_at":"2015-12-15T16:52:51.138Z"}},{"record":{"id":5209960,"domain_id":222002,"parent_id":5209959,"name":"","content":"ALIAS
-        for dns-scratch.herokuapp.com","ttl":86400,"prio":null,"record_type":"TXT","system_record":false,"created_at":"2015-12-15T16:52:51.116Z","updated_at":"2015-12-15T16:52:51.116Z"}}]'
+      encoding: ASCII-8BIT
+      string: '{"data":[{"id":5190381,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns1.dnsimple.com
+        admin.dnsimple.com 1449626174 86400 7200 604800 300","ttl":3600,"priority":null,"type":"SOA","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2018-01-24T20:44:33Z"},{"id":5190382,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns1.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2015-12-09T01:55:04Z"},{"id":5190383,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns2.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2015-12-09T01:55:04Z"},{"id":5190384,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns3.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:05Z","updated_at":"2015-12-09T01:55:05Z"},{"id":5190385,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns4.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:05Z","updated_at":"2015-12-09T01:55:05Z"},{"id":13343287,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"dns-scratch.herokuapp.com","ttl":86400,"priority":null,"type":"ALIAS","regions":["global"],"system_record":false,"created_at":"2018-01-24T20:44:33Z","updated_at":"2018-01-24T20:44:33Z"},{"id":13343288,"zone_id":"dns-scratch.me","parent_id":13343287,"name":"","content":"ALIAS
+        for dns-scratch.herokuapp.com","ttl":86400,"priority":null,"type":"TXT","regions":["global"],"system_record":false,"created_at":"2018-01-24T20:44:33Z","updated_at":"2018-01-24T20:44:33Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":7,"total_pages":1}}'
     http_version:
-  recorded_at: Tue, 15 Dec 2015 16:52:51 GMT
+  recorded_at: Wed, 24 Jan 2018 20:44:33 GMT
 - request:
     method: delete
-    uri: https://api.dnsimple.com/v1/domains/dns-scratch.me/records/5209960
+    uri: https://api.dnsimple.com/v2/<DNSIMPLE_ACCOUNT_ID>/zones/dns-scratch.me/records/13343288
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.32.1
-      X-DNSimple-Token:
-      - "<DNSIMPLE_EMAIL>:<DNSIMPLE_API_TOKEN>"
+      - fog-core/1.44.3 fog-dnsimple/2.0.0
+      Authorization:
+      - "<DNSIMPLE_AUTH_TOKEN>"
       Accept:
       - application/json
       Content-Type:
       - application/json
   response:
     status:
-      code: 200
-      message:
+      code: 204
+      message: No Content
     headers:
       Server:
       - nginx
       Date:
-      - Tue, 15 Dec 2015 16:52:51 GMT
-      Content-Type:
-      - application/json; charset=utf-8
+      - Wed, 24 Jan 2018 20:44:34 GMT
       Connection:
       - keep-alive
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631138519, max-age=31536000
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with
-      Access-Control-Allow-Methods:
-      - GET,POST,PUT,DELETE,OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN, DENY
-      X-XSS-Protection:
-      - '1'
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2383'
+      X-Ratelimit-Reset:
+      - '1516829521'
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 18dd7fa6-97ce-4179-af96-f0eafcc1befb
+      X-Runtime:
+      - '0.116161'
       X-Content-Type-Options:
-      - nosniff, nosniff
+      - nosniff
       X-Download-Options:
       - noopen
+      X-Frame-Options:
+      - DENY
       X-Permitted-Cross-Domain-Policies:
       - none
-      ETag:
-      - W/"99914b932bd37a50b983c5e7c90ae93b"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 51794c03-c3f5-4bff-a5cd-2c766049e78d
-      X-Runtime:
-      - '0.080539'
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
     body:
-      encoding: UTF-8
-      string: "{}"
+      encoding: ASCII-8BIT
+      string: ''
     http_version:
-  recorded_at: Tue, 15 Dec 2015 16:52:52 GMT
+  recorded_at: Wed, 24 Jan 2018 20:44:34 GMT
 - request:
     method: get
-    uri: https://api.dnsimple.com/v1/domains/dns-scratch.me/records
+    uri: https://api.dnsimple.com/v2/<DNSIMPLE_ACCOUNT_ID>/zones/dns-scratch.me/records
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.32.1
-      X-DNSimple-Token:
-      - "<DNSIMPLE_EMAIL>:<DNSIMPLE_API_TOKEN>"
+      - fog-core/1.44.3 fog-dnsimple/2.0.0
+      Authorization:
+      - "<DNSIMPLE_AUTH_TOKEN>"
       Accept:
       - application/json
       Content-Type:
@@ -203,48 +193,46 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: OK
     headers:
       Server:
       - nginx
       Date:
-      - Tue, 15 Dec 2015 16:52:52 GMT
+      - Wed, 24 Jan 2018 20:44:34 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631138519, max-age=31536000
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with
-      Access-Control-Allow-Methods:
-      - GET,POST,PUT,DELETE,OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN, DENY
-      X-XSS-Protection:
-      - '1'
-      X-Content-Type-Options:
-      - nosniff, nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      ETag:
-      - W/"0059fecfb8c4b21beda123d982b8bcc8"
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2382'
+      X-Ratelimit-Reset:
+      - '1516829520'
+      Etag:
+      - W/"fd05b82178615a93a3d5d3ad66c57286"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 5c041ff4-eaf0-4ac6-a7e7-5c518a347ae5
+      - e5e72941-c807-43fb-a7ba-c7e296ebf7d4
       X-Runtime:
-      - '0.031137'
+      - '0.048694'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
     body:
-      encoding: UTF-8
-      string: '[{"record":{"id":5207716,"domain_id":222002,"parent_id":null,"name":"test-record","content":"10.10.10.42","ttl":86400,"prio":null,"record_type":"A","system_record":false,"created_at":"2015-12-14T23:59:43.036Z","updated_at":"2015-12-14T23:59:43.036Z"}},{"record":{"id":5209959,"domain_id":222002,"parent_id":null,"name":"","content":"dns-scratch.herokuapp.com","ttl":86400,"prio":null,"record_type":"ALIAS","system_record":false,"created_at":"2015-12-15T16:52:50.970Z","updated_at":"2015-12-15T16:52:50.970Z"}},{"record":{"id":5190383,"domain_id":222002,"parent_id":null,"name":"","content":"ns2.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:04.938Z","updated_at":"2015-12-09T01:55:04.938Z"}},{"record":{"id":5190382,"domain_id":222002,"parent_id":null,"name":"","content":"ns1.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:04.792Z","updated_at":"2015-12-09T01:55:04.792Z"}},{"record":{"id":5190384,"domain_id":222002,"parent_id":null,"name":"","content":"ns3.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:05.111Z","updated_at":"2015-12-09T01:55:05.111Z"}},{"record":{"id":5190385,"domain_id":222002,"parent_id":null,"name":"","content":"ns4.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:05.250Z","updated_at":"2015-12-09T01:55:05.250Z"}},{"record":{"id":5190381,"domain_id":222002,"parent_id":null,"name":"","content":"ns1.dnsimple.com
-        admin.dnsimple.com 1449626157 86400 7200 604800 300","ttl":3600,"prio":null,"record_type":"SOA","system_record":true,"created_at":"2015-12-09T01:55:04.067Z","updated_at":"2015-12-15T16:52:51.878Z"}}]'
+      encoding: ASCII-8BIT
+      string: '{"data":[{"id":5190381,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns1.dnsimple.com
+        admin.dnsimple.com 1449626175 86400 7200 604800 300","ttl":3600,"priority":null,"type":"SOA","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2018-01-24T20:44:34Z"},{"id":5190382,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns1.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2015-12-09T01:55:04Z"},{"id":5190383,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns2.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2015-12-09T01:55:04Z"},{"id":5190384,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns3.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:05Z","updated_at":"2015-12-09T01:55:05Z"},{"id":5190385,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns4.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:05Z","updated_at":"2015-12-09T01:55:05Z"},{"id":13343287,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"dns-scratch.herokuapp.com","ttl":86400,"priority":null,"type":"ALIAS","regions":["global"],"system_record":false,"created_at":"2018-01-24T20:44:33Z","updated_at":"2018-01-24T20:44:33Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":6,"total_pages":1}}'
     http_version:
-  recorded_at: Tue, 15 Dec 2015 16:52:52 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 24 Jan 2018 20:44:34 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/dnsimple_retrieve_current_records.yml
+++ b/test/fixtures/vcr_cassettes/dnsimple_retrieve_current_records.yml
@@ -2,15 +2,15 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.dnsimple.com/v1/domains/dns-scratch.me/records
+    uri: https://api.dnsimple.com/v2/<DNSIMPLE_ACCOUNT_ID>/zones/dns-scratch.me/records
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.32.1
-      X-DNSimple-Token:
-      - "<DNSIMPLE_EMAIL>:<DNSIMPLE_API_TOKEN>"
+      - fog-core/1.44.3 fog-dnsimple/2.0.0
+      Authorization:
+      - "<DNSIMPLE_AUTH_TOKEN>"
       Accept:
       - application/json
       Content-Type:
@@ -18,48 +18,46 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message: OK
     headers:
       Server:
       - nginx
       Date:
-      - Tue, 15 Dec 2015 00:05:31 GMT
+      - Wed, 24 Jan 2018 20:50:20 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631138519, max-age=31536000
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with
-      Access-Control-Allow-Methods:
-      - GET,POST,PUT,DELETE,OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN, DENY
-      X-XSS-Protection:
-      - '1'
-      X-Content-Type-Options:
-      - nosniff, nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      ETag:
-      - W/"dff6150e36e93050d52081fbac283d71"
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2375'
+      X-Ratelimit-Reset:
+      - '1516829520'
+      Etag:
+      - W/"a237c18f62d6c700ae3ad1deeca64f81"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 25070d07-1e2f-4639-b57c-fa6cf7101c30
+      - 899dc61c-0472-4303-8cf0-42bfe585b524
       X-Runtime:
-      - '0.028447'
+      - '0.051833'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
     body:
-      encoding: UTF-8
-      string: '[{"record":{"id":5207716,"domain_id":222002,"parent_id":null,"name":"test-record","content":"10.10.10.42","ttl":86400,"prio":null,"record_type":"A","system_record":false,"created_at":"2015-12-14T23:59:43.036Z","updated_at":"2015-12-14T23:59:43.036Z"}},{"record":{"id":5190385,"domain_id":222002,"parent_id":null,"name":"","content":"ns4.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:05.250Z","updated_at":"2015-12-09T01:55:05.250Z"}},{"record":{"id":5190384,"domain_id":222002,"parent_id":null,"name":"","content":"ns3.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:05.111Z","updated_at":"2015-12-09T01:55:05.111Z"}},{"record":{"id":5190383,"domain_id":222002,"parent_id":null,"name":"","content":"ns2.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:04.938Z","updated_at":"2015-12-09T01:55:04.938Z"}},{"record":{"id":5190382,"domain_id":222002,"parent_id":null,"name":"","content":"ns1.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:04.792Z","updated_at":"2015-12-09T01:55:04.792Z"}},{"record":{"id":5196953,"domain_id":222002,"parent_id":null,"name":"","content":"dns-scratch.herokuapp.com","ttl":60,"prio":null,"record_type":"ALIAS","system_record":false,"created_at":"2015-12-10T19:56:21.366Z","updated_at":"2015-12-10T19:56:21.366Z"}},{"record":{"id":5190381,"domain_id":222002,"parent_id":null,"name":"","content":"ns1.dnsimple.com
-        admin.dnsimple.com 1449626141 86400 7200 604800 300","ttl":3600,"prio":null,"record_type":"SOA","system_record":true,"created_at":"2015-12-09T01:55:04.067Z","updated_at":"2015-12-14T23:59:57.548Z"}}]'
-    http_version: 
-  recorded_at: Tue, 15 Dec 2015 00:05:31 GMT
-recorded_with: VCR 2.9.3
+      encoding: ASCII-8BIT
+      string: '{"data":[{"id":5190381,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns1.dnsimple.com
+        admin.dnsimple.com 1449626179 86400 7200 604800 300","ttl":3600,"priority":null,"type":"SOA","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2018-01-24T20:50:07Z"},{"id":5190382,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns1.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2015-12-09T01:55:04Z"},{"id":5190383,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns2.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2015-12-09T01:55:04Z"},{"id":5190384,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns3.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:05Z","updated_at":"2015-12-09T01:55:05Z"},{"id":5190385,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns4.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:05Z","updated_at":"2015-12-09T01:55:05Z"},{"id":13343292,"zone_id":"dns-scratch.me","parent_id":null,"name":"test-record","content":"10.10.10.42","ttl":86400,"priority":null,"type":"A","regions":["global"],"system_record":false,"created_at":"2018-01-24T20:46:05Z","updated_at":"2018-01-24T20:46:05Z"},{"id":13343333,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"dns-scratch.herokuapp.com","ttl":60,"priority":null,"type":"ALIAS","regions":["global"],"system_record":false,"created_at":"2018-01-24T20:50:06Z","updated_at":"2018-01-24T20:50:06Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":7,"total_pages":1}}'
+    http_version:
+  recorded_at: Wed, 24 Jan 2018 20:50:20 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/dnsimple_retrieve_current_records_no_alias.yml
+++ b/test/fixtures/vcr_cassettes/dnsimple_retrieve_current_records_no_alias.yml
@@ -2,15 +2,15 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.dnsimple.com/v1/domains/dns-scratch.me/records
+    uri: https://api.dnsimple.com/v2/<DNSIMPLE_ACCOUNT_ID>/zones/dns-scratch.me/records
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.32.1
-      X-DNSimple-Token:
-      - "<DNSIMPLE_EMAIL>:<DNSIMPLE_API_TOKEN>"
+      - fog-core/1.44.3 fog-dnsimple/2.0.0
+      Authorization:
+      - "<DNSIMPLE_AUTH_TOKEN>"
       Accept:
       - application/json
       Content-Type:
@@ -18,48 +18,46 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: OK
     headers:
       Server:
       - nginx
       Date:
-      - Tue, 15 Dec 2015 00:05:31 GMT
+      - Wed, 24 Jan 2018 21:22:09 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631138519, max-age=31536000
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with
-      Access-Control-Allow-Methods:
-      - GET,POST,PUT,DELETE,OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN, DENY
-      X-XSS-Protection:
-      - '1'
-      X-Content-Type-Options:
-      - nosniff, nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      ETag:
-      - W/"dff6150e36e93050d52081fbac283d71"
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2374'
+      X-Ratelimit-Reset:
+      - '1516829520'
+      Etag:
+      - W/"a237c18f62d6c700ae3ad1deeca64f81"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 25070d07-1e2f-4639-b57c-fa6cf7101c30
+      - 2ef3ca56-0bda-4c18-8490-4d55c0766b60
       X-Runtime:
-      - '0.028447'
+      - '0.025931'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
     body:
-      encoding: UTF-8
-      string: '[{"record":{"id":5207716,"domain_id":222002,"parent_id":null,"name":"test-record","content":"10.10.10.42","ttl":86400,"prio":null,"record_type":"A","system_record":false,"created_at":"2015-12-14T23:59:43.036Z","updated_at":"2015-12-14T23:59:43.036Z"}},{"record":{"id":5190385,"domain_id":222002,"parent_id":null,"name":"","content":"ns4.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:05.250Z","updated_at":"2015-12-09T01:55:05.250Z"}},{"record":{"id":5190384,"domain_id":222002,"parent_id":null,"name":"","content":"ns3.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:05.111Z","updated_at":"2015-12-09T01:55:05.111Z"}},{"record":{"id":5190383,"domain_id":222002,"parent_id":null,"name":"","content":"ns2.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:04.938Z","updated_at":"2015-12-09T01:55:04.938Z"}},{"record":{"id":5190382,"domain_id":222002,"parent_id":null,"name":"","content":"ns1.dnsimple.com","ttl":3600,"prio":null,"record_type":"NS","system_record":true,"created_at":"2015-12-09T01:55:04.792Z","updated_at":"2015-12-09T01:55:04.792Z"}},{"record":{"id":5190381,"domain_id":222002,"parent_id":null,"name":"","content":"ns1.dnsimple.com
-        admin.dnsimple.com 1449626141 86400 7200 604800 300","ttl":3600,"prio":null,"record_type":"SOA","system_record":true,"created_at":"2015-12-09T01:55:04.067Z","updated_at":"2015-12-14T23:59:57.548Z"}}]'
+      encoding: ASCII-8BIT
+      string: '{"data":[{"id":5190381,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns1.dnsimple.com
+        admin.dnsimple.com 1449626179 86400 7200 604800 300","ttl":3600,"priority":null,"type":"SOA","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2018-01-24T20:50:07Z"},{"id":5190382,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns1.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2015-12-09T01:55:04Z"},{"id":5190383,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns2.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:04Z","updated_at":"2015-12-09T01:55:04Z"},{"id":5190384,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns3.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:05Z","updated_at":"2015-12-09T01:55:05Z"},{"id":5190385,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns4.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2015-12-09T01:55:05Z","updated_at":"2015-12-09T01:55:05Z"},{"id":13343292,"zone_id":"dns-scratch.me","parent_id":null,"name":"test-record","content":"10.10.10.42","ttl":86400,"priority":null,"type":"A","regions":["global"],"system_record":false,"created_at":"2018-01-24T20:46:05Z","updated_at":"2018-01-24T20:46:05Z"},{"id":13343333,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"dns-scratch.herokuapp.com","ttl":60,"priority":null,"type":"ALIAS","regions":["global"],"system_record":false,"created_at":"2018-01-24T20:50:06Z","updated_at":"2018-01-24T20:50:06Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":7,"total_pages":1}}'
     http_version:
-  recorded_at: Tue, 15 Dec 2015 00:05:31 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 24 Jan 2018 21:22:09 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/dnsimple_zones.yml
+++ b/test/fixtures/vcr_cassettes/dnsimple_zones.yml
@@ -2,15 +2,15 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.dnsimple.com/v1/domains
+    uri: https://api.dnsimple.com/v2/dnsimple_account_id/domains
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.32.1
-      X-DNSimple-Token:
-      - "<DNSIMPLE_EMAIL>:<DNSIMPLE_API_TOKEN>"
+      - fog-core/1.44.3 fog-dnsimple/2.0.0
+      Authorization:
+      - "<DNSIMPLE_AUTH_TOKEN>"
       Accept:
       - application/json
       Content-Type:
@@ -18,47 +18,45 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message: OK
     headers:
       Server:
       - nginx
       Date:
-      - Mon, 14 Dec 2015 23:56:48 GMT
+      - Wed, 24 Jan 2018 20:43:01 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=631138519, max-age=31536000
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with
-      Access-Control-Allow-Methods:
-      - GET,POST,PUT,DELETE,OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN, DENY
-      X-XSS-Protection:
-      - '1'
-      X-Content-Type-Options:
-      - nosniff, nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      ETag:
-      - W/"d81d664fe48d35b7022bf36f13eb0317"
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2386'
+      X-Ratelimit-Reset:
+      - '1516829521'
+      Etag:
+      - W/"dfd12385d3b4f989d238cc3397cc28c8"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - e4f4f510-07d1-4d27-8229-571d99ffeabc
+      - f4be25f6-93a3-4d16-adfc-fcfaddcf69cf
       X-Runtime:
-      - '0.046501'
+      - '0.029276'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
     body:
-      encoding: UTF-8
-      string: '[{"domain":{"id":222002,"user_id":null,"registrant_id":null,"name":"dns-scratch.me","unicode_name":"dns-scratch.me","token":"9lzTQu3SAtBZ0Ng5R504ryu0m1TztavP","state":"hosted","language":null,"lockable":true,"auto_renew":false,"whois_protected":false,"record_count":7,"service_count":0,"expires_on":null,"created_at":"2015-12-09T01:55:04.032Z","updated_at":"2015-12-09T01:55:04.032Z"}}]'
-    http_version: 
-  recorded_at: Mon, 14 Dec 2015 23:56:48 GMT
-recorded_with: VCR 2.9.3
+      encoding: ASCII-8BIT
+      string: '{"data":[{"id":222002,"account_id":"dnsimple_account_id","registrant_id":null,"name":"dns-scratch.me","unicode_name":"dns-scratch.me","token":"9lzTQu3SAtBZ0Ng5R504ryu0m1TztavP","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2015-12-09T01:55:04Z","updated_at":"2015-12-09T01:55:04Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}'
+    http_version:
+  recorded_at: Wed, 24 Jan 2018 20:43:01 GMT
+recorded_with: VCR 4.0.0

--- a/test/providers/dnsimple_test.rb
+++ b/test/providers/dnsimple_test.rb
@@ -18,8 +18,8 @@ class DNSimpleTest < Minitest::Test
       "name" => "a",
       "content" => "8.8.8.8",
       "ttl" => 60,
-      "prio" => nil,
-      "record_type" => "A",
+      "priority" => nil,
+      "type" => "A",
       "system_record" => false,
       "created_at" => "2015-12-11T16:30:17.380Z",
       "updated_at" => "2015-12-11T16:30:17.380Z"
@@ -39,8 +39,8 @@ class DNSimpleTest < Minitest::Test
       "name" => "aaaa",
       "content" => "2001:0db8:85a3:0000:0000:EA75:1337:BEEF",
       "ttl" => 60,
-      "prio" => nil,
-      "record_type" => "AAAA",
+      "priority" => nil,
+      "type" => "AAAA",
       "system_record" => false,
       "created_at" => "2015-12-11T16:30:29.630Z",
       "updated_at" => "2015-12-11T16:30:29.630Z"
@@ -60,8 +60,8 @@ class DNSimpleTest < Minitest::Test
       "name" => "",
       "content" => "dns-scratch.herokuapp.com",
       "ttl" => 60,
-      "prio" => nil,
-      "record_type" => "ALIAS",
+      "priority" => nil,
+      "type" => "ALIAS",
       "system_record" => false,
       "created_at" => "2015-12-10T19:56:21.366Z",
       "updated_at" => "2015-12-10T19:56:21.366Z"
@@ -81,8 +81,8 @@ class DNSimpleTest < Minitest::Test
       "name" => "cname",
       "content" => "dns-scratch.me",
       "ttl" => 60,
-      "prio" => nil,
-      "record_type" => "CNAME",
+      "priority" => nil,
+      "type" => "CNAME",
       "system_record" => false,
       "created_at" => "2015-12-11T16:30:41.284Z",
       "updated_at" => "2015-12-11T16:30:41.284Z"
@@ -102,8 +102,8 @@ class DNSimpleTest < Minitest::Test
       "name" => "mx",
       "content" => "mail-server.example.com",
       "ttl" => 60,
-      "prio" => 10,
-      "record_type" => "MX",
+      "priority" => 10,
+      "type" => "MX",
       "system_record" => false,
       "created_at" => "2015-12-10T19:58:20.474Z",
       "updated_at" => "2015-12-11T16:31:06.956Z"
@@ -124,8 +124,8 @@ class DNSimpleTest < Minitest::Test
       "name" => "",
       "content" => "ns1.dnsimple.com",
       "ttl" => 3600,
-      "prio" => nil,
-      "record_type" => "NS",
+      "priority" => nil,
+      "type" => "NS",
       "system_record" => true,
       "created_at" => "2015-12-09T01:55:04.792Z",
       "updated_at" => "2015-12-09T01:55:04.792Z"
@@ -145,8 +145,8 @@ class DNSimpleTest < Minitest::Test
       "name" => "_service._TCP.srv",
       "content" => "47 80 target-srv.dns-scratch.me",
       "ttl" => 60,
-      "prio" => 10,
-      "record_type" => "SRV",
+      "priority" => 10,
+      "type" => "SRV",
       "system_record" => false,
       "created_at" => "2015-12-11T16:33:10.947Z",
       "updated_at" => "2015-12-11T16:33:10.947Z"
@@ -169,8 +169,8 @@ class DNSimpleTest < Minitest::Test
       "name" => "",
       "value" => "ns1.dnsimple.com admin.dnsimple.com 2013021901 86400 7200 604800 300",
       "ttl" => 3600,
-      "prio" => nil,
-      "record_type" => "SOA",
+      "priority" => nil,
+      "type" => "SOA",
       "system_record" => true,
       "created_at" => "2013-02-19T22:58:25.148Z",
       "updated_at" => "2013-02-19T22:58:38.751Z"
@@ -187,8 +187,8 @@ class DNSimpleTest < Minitest::Test
       "name" => "txt",
       "content" => "Hello, world!",
       "ttl" => 60,
-      "prio" => nil,
-      "record_type" => "TXT",
+      "priority" => nil,
+      "type" => "TXT",
       "system_record" => false,
       "created_at" => "2015-12-11T16:36:26.504Z",
       "updated_at" => "2015-12-11T16:36:26.504Z"
@@ -237,7 +237,7 @@ class DNSimpleTest < Minitest::Test
         ttl: 86400,
         fqdn: 'test-record.dns-scratch.me',
         address: '10.10.10.42',
-        record_id: 5207716
+        record_id: 13343292
       }),
       Record::NS.new({
         zone: 'dns-scratch.me',
@@ -272,13 +272,13 @@ class DNSimpleTest < Minitest::Test
         ttl: 60,
         fqdn: 'dns-scratch.me',
         alias: 'dns-scratch.herokuapp.com',
-        record_id: 5196953
+        record_id: 13343333
       }),
     ]
 
     VCR.use_cassette 'dnsimple_retrieve_current_records' do
       records = @dnsimple.retrieve_current_records(zone: @zone_name)
-      assert_equal records_arr, records
+      assert_equal records_arr.sort_by(&:to_s), records.sort_by(&:to_s)
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,6 @@ class Minitest::Test
 
   SECRET_KEYS = {
     'google_cloud_dns' =>  %w(
-      type
       private_key_id
       private_key
       client_email
@@ -31,7 +30,7 @@ class Minitest::Test
       username
     ),
     'dnsimple' => %w(
-      email
+      account_id
       api_token
     )
   }


### PR DESCRIPTION
`record_store` is currently using the DNSimple adapter from the `fog` gem. This adapter is quite old, it was extracted in 2016 into a `fog-dnsimple`.

Moreover, I've just released a new version of `fog-dnsimple` (fog/fog-dnsimple#3) that uses our API v2. API v1 are deprecated since 2016, and we are now in the process of shutting them down.

I need some help here to update the CircleCI integration to use the new auth mechanism (specifically an API v2 account token you can generate from the Shopify account, and the account ID). /cc @charlescng @es @sbfaulkner 

Technically speaking the client could fetch the ID from the token, but due to the way Fog is structured I decided to request it explicitly.

Unfortunately I was not able to run the integration specs locally because of the fixture failures described in https://github.com/Shopify/record_store/issues/45