### PR TITLE
Decrypt secrets on rollback

### DIFF
--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -246,12 +246,18 @@ module RecordStore
           `git checkout #{ENV['LAST_DEPLOYED_SHA']}`
           abort "Checkout of old commit failed" if $?.exitstatus != 0
 
+          `record-store secrets`
+          abort "Decrypt secrets failed" if $?.exitstatus != 0
+
           `record-store assert_empty_diff`
           abort "Dyn status has diverged!" if $?.exitstatus != 0
 
           puts "Checkout git SHA #{ENV['REVISION']}"
           `git checkout #{ENV['REVISION']}`
           abort "Checkout of new commit failed" if $?.exitstatus != 0
+
+          `record-store secrets`
+          abort "Decrypt secrets failed" if $?.exitstatus != 0
         end
       end
     end

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.0.2'.freeze
+  VERSION = '5.0.3'.freeze
 end


### PR DESCRIPTION
This fixes (maybe) a bug where secrets are not decrypted when a rollback happens while executing `record-store validate_initial_state`.

@Shopify/edgescale 