### PR TITLE
Fix bug where only 30 records are returned

### DIFF
--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -38,7 +38,7 @@ module RecordStore
 
       # returns an array of Record objects that match the records which exist in the provider
       def retrieve_current_records(zone:, stdout: $stdout)
-        session.list_records(zone).body["data"].map do |record_body|
+        session.list_all_records(zone).body["data"].map do |record_body|
           begin
             build_from_api(record_body, zone)
           rescue StandardError

--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'fog-json'
   spec.add_runtime_dependency 'fog-xml'
   spec.add_runtime_dependency 'fog-dynect', '~> 0.2.0'
-  spec.add_runtime_dependency 'fog-dnsimple', '~> 2.0.0'
+  spec.add_runtime_dependency 'fog-dnsimple', '~> 2.1.0'
   spec.add_runtime_dependency 'google-cloud-dns'
 
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
API v2 by default paginates the record, and the switch to API v2 caused the call to list records to return only 30 records.

I updated fog-dnsimple to be able to fetch all records. See https://github.com/fog/fog-dnsimple/issues/4

I could not run the specs locally as VCR exploded. FYI the underlying call is now passing pagination parameters, therefore I suspect cassettes has to be updated. Sorry for that. :(

/cc @dturn 