### PR TITLE
Refactor for more consistent output

### DIFF
--- a/lib/record_store/changeset.rb
+++ b/lib/record_store/changeset.rb
@@ -57,7 +57,11 @@ module RecordStore
     end
 
     def apply
+      puts "Applying #{additions.size} additions, #{removals.size} removals, and #{updates.size} updates..."
+
       provider.apply_changeset(self)
+
+      puts "Published #{zone} changes to #{provider}\n\n"
     end
 
     def unchanged

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -69,25 +69,21 @@ module RecordStore
 
       # Applies changeset to provider
       def apply_changeset(changeset, stdout = $stdout)
-        stdout.puts "Applying #{changeset.additions.size} additions, #{changeset.removals.size} removals, & #{changeset.updates.size} updates..."
-
         changeset.changes.each do |change|
           case change.type
-            when :removal;
-              stdout.puts "Removing #{change.record}..."
-              remove(change.record, changeset.zone)
-            when :addition;
-              stdout.puts "Creating #{change.record}..."
-              add(change.record, changeset.zone)
-            when :update;
-              stdout.puts "Updating record with ID #{change.id} to #{change.record}..."
-              update(change.id, change.record, changeset.zone)
-            else
-              raise ArgumentError, "Unknown change type #{change.type.inspect}"
+          when :removal
+            stdout.puts "Removing #{change.record}..."
+            remove(change.record, changeset.zone)
+          when :addition
+            stdout.puts "Creating #{change.record}..."
+            add(change.record, changeset.zone)
+          when :update
+            stdout.puts "Updating record with ID #{change.id} to #{change.record}..."
+            update(change.id, change.record, changeset.zone)
+          else
+            raise ArgumentError, "Unknown change type #{change.type.inspect}"
           end
         end
-
-        puts "\nPublished #{changeset.zone} changes to #{changeset.provider.to_s}\n"
       end
 
       # Returns an array of the zones managed by provider as strings

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -69,27 +69,25 @@ module RecordStore
 
       # Applies changeset to provider
       def apply_changeset(changeset, stdout = $stdout)
-        begin
-          stdout.puts "Applying #{changeset.additions.size} additions, #{changeset.removals.size} removals, & #{changeset.updates.size} updates..."
+        stdout.puts "Applying #{changeset.additions.size} additions, #{changeset.removals.size} removals, & #{changeset.updates.size} updates..."
 
-          changeset.changes.each do |change|
-            case change.type
-              when :removal;
-                stdout.puts "Removing #{change.record}..."
-                remove(change.record, changeset.zone)
-              when :addition;
-                stdout.puts "Creating #{change.record}..."
-                add(change.record, changeset.zone)
-              when :update;
-                stdout.puts "Updating record with ID #{change.id} to #{change.record}..."
-                update(change.id, change.record, changeset.zone)
-              else
-                raise ArgumentError, "Unknown change type #{change.type.inspect}"
-            end
+        changeset.changes.each do |change|
+          case change.type
+            when :removal;
+              stdout.puts "Removing #{change.record}..."
+              remove(change.record, changeset.zone)
+            when :addition;
+              stdout.puts "Creating #{change.record}..."
+              add(change.record, changeset.zone)
+            when :update;
+              stdout.puts "Updating record with ID #{change.id} to #{change.record}..."
+              update(change.id, change.record, changeset.zone)
+            else
+              raise ArgumentError, "Unknown change type #{change.type.inspect}"
           end
-
-          puts "\nPublished #{changeset.zone} changes to #{changeset.provider.to_s}\n"
         end
+
+        puts "\nPublished #{changeset.zone} changes to #{changeset.provider.to_s}\n"
       end
 
       # Returns an array of the zones managed by provider as strings

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -29,17 +29,15 @@ module RecordStore
 
       # Applies changeset to provider
       def apply_changeset(changeset, stdout = $stdout)
-        begin
-          thaw_zone(changeset.zone)
-          super
-          publish(changeset.zone)
-        rescue StandardError
-          puts "An exception occurred while applying DNS changes, deleting changeset"
-          discard_change_set(changeset.zone)
-          raise
-        ensure
-          freeze_zone(changeset.zone)
-        end
+        thaw_zone(changeset.zone)
+        super
+        publish(changeset.zone)
+      rescue StandardError
+        puts "An exception occurred while applying DNS changes, deleting changeset"
+        discard_change_set(changeset.zone)
+        raise
+      ensure
+        freeze_zone(changeset.zone)
       end
 
       # returns an array of Record objects that match the records which exist in the provider

--- a/lib/record_store/provider/google_cloud_dns.rb
+++ b/lib/record_store/provider/google_cloud_dns.rb
@@ -4,13 +4,17 @@ module RecordStore
   class Provider::GoogleCloudDNS < Provider
     class << self
       def apply_changeset(changeset, stdout = $stdout)
+        stdout.puts "Applying #{changeset.additions.size} additions, #{changeset.removals.size} removals, & #{changeset.updates.size} updates..."
+
         zone = session.zone(convert_to_name(changeset.zone))
 
         deletions = convert_records_to_gcloud_record_sets(zone, changeset.current_records)
         additions = convert_records_to_gcloud_record_sets(zone, changeset.desired_records)
 
-        # The Google API library will handle applying the changeset transactioanlly
+        # The Google API library will handle applying the changeset transactionally
         zone.update(additions, deletions)
+
+        puts "\nPublished #{changeset.zone} changes to #{changeset.provider.to_s}\n"
       end
 
       # returns an array of Record objects that match the records which exist in the provider

--- a/lib/record_store/provider/google_cloud_dns.rb
+++ b/lib/record_store/provider/google_cloud_dns.rb
@@ -4,8 +4,6 @@ module RecordStore
   class Provider::GoogleCloudDNS < Provider
     class << self
       def apply_changeset(changeset, stdout = $stdout)
-        stdout.puts "Applying #{changeset.additions.size} additions, #{changeset.removals.size} removals, & #{changeset.updates.size} updates..."
-
         zone = session.zone(convert_to_name(changeset.zone))
 
         deletions = convert_records_to_gcloud_record_sets(zone, changeset.current_records)
@@ -13,8 +11,6 @@ module RecordStore
 
         # The Google API library will handle applying the changeset transactionally
         zone.update(additions, deletions)
-
-        puts "\nPublished #{changeset.zone} changes to #{changeset.provider.to_s}\n"
       end
 
       # returns an array of Record objects that match the records which exist in the provider


### PR DESCRIPTION
I noticed that when the GoogleCloudDNS provider was used, that some of the progress messages were not produced.

The ones for specific operations (Removing/Creating/Updating) are not as simple, but this PR at least moves the Apply and Published output to the common function in the changeset that invokes the individual providers.

context: for dynect and dnsimple we have to actually apply the individual changes (which is what the base implementation of `apply_changeset` does... however, google never calls the base implementation and instead overrides it 