### PR TITLE
refactor to make provider add/remove/update private

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,28 +96,6 @@ Provider API interactions are tested with [VCR](https://github.com/vcr/vcr). To 
 Outline of [`Provider`](lib/record_store/provider.rb):
 ```ruby
 class Provider
-  # Creates a new record to the zone. It is expected this call modifies external state.
-  #
-  # Arguments:
-  # record - a kind of `Record`
-  def add(record)
-  end
-
-  # Deletes an existing record from the zone. It is expected this call modifies external state.
-  #
-  # Arguments:
-  # record - a kind of `Record`
-  def remove(record)
-  end
-
-  # Updates an existing record in the zone. It is expected this call modifies external state.
-  #
-  # Arguments:
-  # id - provider specific ID of record to update
-  # record - a kind of `Record` which the record with `id` should be updated to
-  def update(id, record)
-  end
-
   # Downloads all the records from the provider.
   #
   # Returns: an array of `Record` for each record in the provider's zone
@@ -140,6 +118,35 @@ class Provider
 
   # Unlocks the zone to allow making changes (see `Provider#freeze_zone`).
   def thaw
+  end
+
+  private
+
+  ######## NOTE ########
+  # The following methods only need to be implemented if you are using the base provider's
+  # implementation of apply_changeset to manage the contents of the changeset (or transaction).
+  ######################
+
+  # Creates a new record to the zone. It is expected this call modifies external state.
+  #
+  # Arguments:
+  # record - a kind of `Record`
+  def add(record)
+  end
+
+  # Deletes an existing record from the zone. It is expected this call modifies external state.
+  #
+  # Arguments:
+  # record - a kind of `Record`
+  def remove(record)
+  end
+
+  # Updates an existing record in the zone. It is expected this call modifies external state.
+  #
+  # Arguments:
+  # id - provider specific ID of record to update
+  # record - a kind of `Record` which the record with `id` should be updated to
+  def update(id, record)
   end
 end
 ```

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -55,18 +55,6 @@ module RecordStore
         raise NotImplementedError
       end
 
-      def add(record)
-        raise NotImplementedError
-      end
-
-      def remove(record)
-        raise NotImplementedError
-      end
-
-      def update(id, record)
-        raise NotImplementedError
-      end
-
       # Applies changeset to provider
       def apply_changeset(changeset, stdout = $stdout)
         begin
@@ -115,6 +103,20 @@ module RecordStore
 
       def to_s
         self.name.demodulize
+      end
+
+      private
+
+      def add(record)
+        raise NotImplementedError
+      end
+
+      def remove(record)
+        raise NotImplementedError
+      end
+
+      def update(id, record)
+        raise NotImplementedError
       end
     end
   end

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -7,6 +7,25 @@ module RecordStore
         true
       end
 
+      # returns an array of Record objects that match the records which exist in the provider
+      def retrieve_current_records(zone:, stdout: $stdout)
+        session.zones.all_records(account_id, zone).data.map do |record|
+          begin
+            build_from_api(record, zone)
+          rescue StandardError
+            stdout.puts "Cannot build record: #{record}"
+            raise
+          end
+        end.compact
+      end
+
+      # Returns an array of the zones managed by provider as strings
+      def zones
+        session.zones.all_zones(account_id).data.map(&:name)
+      end
+
+      private
+
       def add(record, zone)
         record_hash = api_hash(record, zone)
         res = session.zones.create_record(account_id, zone, record_hash)
@@ -28,25 +47,6 @@ module RecordStore
       def update(id, record, zone)
         session.zones.update_record(account_id, zone, id, api_hash(record, zone))
       end
-
-      # returns an array of Record objects that match the records which exist in the provider
-      def retrieve_current_records(zone:, stdout: $stdout)
-        session.zones.all_records(account_id, zone).data.map do |record|
-          begin
-            build_from_api(record, zone)
-          rescue StandardError
-            stdout.puts "Cannot build record: #{record}"
-            raise
-          end
-        end.compact
-      end
-
-      # Returns an array of the zones managed by provider as strings
-      def zones
-        session.zones.all_zones(account_id).data.map(&:name)
-      end
-
-      private
 
       def session
         @dns ||= Dnsimple::Client.new(

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -11,18 +11,6 @@ module RecordStore
         session.put_zone(zone, thaw: true)
       end
 
-      def add(record, zone)
-        session.post_record(record.type, zone, record.fqdn, record.rdata, 'ttl' => record.ttl)
-      end
-
-      def remove(record, zone)
-        session.delete_record(record.type, zone, record.fqdn, record.id)
-      end
-
-      def update(id, record, zone)
-        session.put_record(record.type, zone, record.fqdn, record.rdata, 'ttl' => record.ttl, 'record_id' => id)
-      end
-
       def publish(zone)
         session.put_zone(zone, publish: true)
       end
@@ -61,6 +49,18 @@ module RecordStore
       end
 
       private
+
+      def add(record, zone)
+        session.post_record(record.type, zone, record.fqdn, record.rdata, 'ttl' => record.ttl)
+      end
+
+      def remove(record, zone)
+        session.delete_record(record.type, zone, record.fqdn, record.id)
+      end
+
+      def update(id, record, zone)
+        session.put_record(record.type, zone, record.fqdn, record.rdata, 'ttl' => record.ttl, 'record_id' => id)
+      end
 
       def discard_change_set(zone)
         session.request(expects: 200, method: :delete, path: "ZoneChanges/#{zone}")


### PR DESCRIPTION
add/remove/update should not be public - they are not called except in the base `Provider#apply_changeset`

this PR makes them private and closes #43 
