### PR TITLE
Txt record quoting and escaping

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@
 name: recordstore
 
 up:
-  - ruby: 2.3.1
+  - ruby: 2.4.3
   - bundler
 
 commands:

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -85,7 +85,7 @@ module RecordStore
         when 'NS'
           record.merge!(nsdname: api_record.content)
         when 'SPF', 'TXT'
-          record.merge!(txtdata: api_record.content.gsub(';', '\;'))
+          record.merge!(txtdata: api_record.content.gsub('\"', '"').gsub(';', '\;'))
         when 'SRV'
           weight, port, host = api_record.content.split(' ')
 

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -124,7 +124,7 @@ module RecordStore
         when 'NS'
           record_hash[:content] = record.nsdname.chomp('.')
         when 'SPF', 'TXT'
-          record_hash[:content] = record.txtdata.gsub('\;', ';')
+          record_hash[:content] = record.txtdata.gsub('"', '\"').gsub('\;', ';')
         when 'SRV'
           record_hash[:content] = "#{record.weight} #{record.port} #{record.target.chomp('.')}"
           record_hash[:priority] = record.priority

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -85,7 +85,7 @@ module RecordStore
         when 'NS'
           record.merge!(nsdname: api_record.content)
         when 'SPF', 'TXT'
-          record.merge!(txtdata: api_record.content.gsub('\"', '"').gsub(';', '\;'))
+          record.merge!(txtdata: Record::TXT.unescape(api_record.content).gsub(';', '\;'))
         when 'SRV'
           weight, port, host = api_record.content.split(' ')
 
@@ -124,7 +124,7 @@ module RecordStore
         when 'NS'
           record_hash[:content] = record.nsdname.chomp('.')
         when 'SPF', 'TXT'
-          record_hash[:content] = record.txtdata.gsub('"', '\"').gsub('\;', ';')
+          record_hash[:content] = Record::TXT.escape(record.txtdata).gsub('\;', ';')
         when 'SRV'
           record_hash[:content] = "#{record.weight} #{record.port} #{record.target.chomp('.')}"
           record_hash[:priority] = record.priority

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -92,15 +92,18 @@ module RecordStore
       end
 
       def build_from_api(api_record)
-        record = api_record.merge(api_record.fetch('rdata')).slice!('rdata').symbolize_keys
+        rdata = api_record.fetch('rdata')
+        record = api_record.merge(rdata).slice!('rdata').symbolize_keys
 
-        return if record.fetch(:record_type) == 'SOA'
+        type = record.fetch(:record_type)
+        return if type == 'SOA'
 
-        unless record.fetch(:fqdn).ends_with?('.')
-          record[:fqdn] = "#{record.fetch(:fqdn)}."
-        end
+        record[:txtdata].gsub!('\"', '"') if type == 'TXT'
 
-        Record.const_get(record.fetch(:record_type)).new(record)
+        fqdn = record.fetch(:fqdn)
+        record[:fqdn] = "#{fqdn}." unless fqdn.ends_with?('.')
+
+        Record.const_get(type).new(record)
       end
     end
   end

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -98,7 +98,7 @@ module RecordStore
         type = record.fetch(:record_type)
         return if type == 'SOA'
 
-        record[:txtdata].gsub!('\"', '"') if type == 'TXT'
+        record[:txtdata] = Record::TXT.unescape(record[:txtdata]) if type == 'TXT'
 
         fqdn = record.fetch(:fqdn)
         record[:fqdn] = "#{fqdn}." unless fqdn.ends_with?('.')

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -98,7 +98,7 @@ module RecordStore
         type = record.fetch(:record_type)
         return if type == 'SOA'
 
-        record[:txtdata] = Record::TXT.unescape(record[:txtdata]) if type == 'TXT'
+        record[:txtdata] = Record::TXT.unescape(record[:txtdata]) if %w[SPF TXT].include?(type)
 
         fqdn = record.fetch(:fqdn)
         record[:fqdn] = "#{fqdn}." unless fqdn.ends_with?('.')

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -49,7 +49,7 @@ module RecordStore
       private
 
       def add(record, zone)
-        session.post_record(record.type, zone, record.fqdn, record.rdata, 'ttl' => record.ttl)
+        session.post_record(record.type, zone, record.fqdn, api_rdata(record), 'ttl' => record.ttl)
       end
 
       def remove(record, zone)
@@ -57,7 +57,7 @@ module RecordStore
       end
 
       def update(id, record, zone)
-        session.put_record(record.type, zone, record.fqdn, record.rdata, 'ttl' => record.ttl, 'record_id' => id)
+        session.put_record(record.type, zone, record.fqdn, api_rdata(record), 'ttl' => record.ttl, 'record_id' => id)
       end
 
       def discard_change_set(zone)
@@ -80,6 +80,15 @@ module RecordStore
 
       def secrets
         super.fetch('dynect')
+      end
+
+      def api_rdata(record)
+        case record.type
+        when 'TXT'
+          { txtdata: record.rdata_txt }
+        else
+          record.rdata
+        end
       end
 
       def build_from_api(api_record)

--- a/lib/record_store/provider/google_cloud_dns.rb
+++ b/lib/record_store/provider/google_cloud_dns.rb
@@ -98,7 +98,7 @@ module RecordStore
         when 'NS'
           record_params.merge!(nsdname: record.data[0])
         when 'SPF', 'TXT'
-          txtdata = record.data[0].sub(/\A"(.*)"\z/, '\1').gsub('\"', '"').gsub(';', '\;')
+          txtdata = Record::TXT.unquote(record.data[0]).gsub(';', '\;')
           record_params.merge!(txtdata: txtdata)
         when 'SRV'
           priority, weight, port, target = record.data[0].split(' ')

--- a/lib/record_store/provider/google_cloud_dns.rb
+++ b/lib/record_store/provider/google_cloud_dns.rb
@@ -98,7 +98,8 @@ module RecordStore
         when 'NS'
           record_params.merge!(nsdname: record.data[0])
         when 'SPF', 'TXT'
-          record_params.merge!(txtdata: record.data[0].gsub(';', '\;'))
+          txtdata = record.data[0].sub(/\A"(.*)"\z/, '\1').gsub('\"', '"').gsub(';', '\;')
+          record_params.merge!(txtdata: txtdata)
         when 'SRV'
           priority, weight, port, target = record.data[0].split(' ')
 

--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -35,7 +35,7 @@ module RecordStore
     end
 
     def type
-      self.class.name.split('::').last
+      self.class.name.demodulize
     end
 
     def ==(other)
@@ -65,8 +65,7 @@ module RecordStore
     end
 
     def to_s
-      rr_type = self.class.name.demodulize
-      "[#{rr_type}Record] #{fqdn} #{ttl} IN #{rr_type} #{rdata_txt}"
+      "[#{type}Record] #{fqdn} #{ttl} IN #{type} #{rdata_txt}"
     end
 
     protected

--- a/lib/record_store/record/txt.rb
+++ b/lib/record_store/record/txt.rb
@@ -5,6 +5,24 @@ module RecordStore
     validates :txtdata, presence: true, length: { maximum: 255 }
     validate :escaped_semicolons
 
+    class << self
+      def escape(value)
+        value.gsub('"', '\"')
+      end
+
+      def quote(value)
+        %("#{escape(value)}")
+      end
+
+      def unescape(value)
+        value.gsub('\"', '"')
+      end
+
+      def unquote(value)
+        unescape(value.sub(/\A"(.*)"\z/, '\1'))
+      end
+    end
+
     def initialize(record)
       super
       @txtdata = record.fetch(:txtdata)
@@ -15,7 +33,7 @@ module RecordStore
     end
 
     def rdata_txt
-      %("#{txtdata.gsub('"', '\"')}")
+      Record::TXT.quote(txtdata)
     end
 
     private

--- a/lib/record_store/record/txt.rb
+++ b/lib/record_store/record/txt.rb
@@ -10,16 +10,12 @@ module RecordStore
       @txtdata = record.fetch(:txtdata)
     end
 
-    def to_s
-      "[#{type}Record] #{fqdn} #{ttl} IN #{type} \"#{rdata_txt}\""
-    end
-
     def rdata
       { txtdata: txtdata }
     end
 
     def rdata_txt
-      txtdata
+      %("#{txtdata.gsub('"', '\"')}")
     end
 
     private

--- a/test/providers/google_cloud_dns_test.rb
+++ b/test/providers/google_cloud_dns_test.rb
@@ -115,7 +115,7 @@ class GoogleCloudDNSTest < Minitest::Test
         'txt.dns-test.shopify.io.',
         'TXT',
         60,
-        ['Hello, world!']
+        ['"Hello, world!"']
       )
     )
 
@@ -219,13 +219,13 @@ class GoogleCloudDNSTest < Minitest::Test
         fqdn: 'txt.dns-scratch.me',
         zone: 'dns-scratch.me',
         ttl: 300,
-        txtdata: '"test"'
+        txtdata: 'test'
       ),
       Record::TXT.new(
         fqdn: 'txt.dns-scratch.me',
         zone: 'dns-scratch.me',
         ttl: 300,
-        txtdata: '"asdf"'
+        txtdata: 'asdf'
       ),
       Record::A.new(
         zone: 'dns-scratch.me',

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -121,7 +121,7 @@ class RecordTest < Minitest::Test
     assert_equal '10 mail-server.example.com.', RECORD_FIXTURES[:mx].rdata_txt
     assert_equal 'ns1.dynect.net.', RECORD_FIXTURES[:ns].rdata_txt
     assert_equal '10 47 80 target-srv.dns-test.shopify.io.', RECORD_FIXTURES[:srv].rdata_txt
-    assert_equal 'Hello, world!', RECORD_FIXTURES[:txt].rdata_txt
+    assert_equal '"Hello, world!"', RECORD_FIXTURES[:txt].rdata_txt
     assert_equal 'v=spf1 -all', RECORD_FIXTURES[:spf].rdata_txt
   end
 
@@ -135,5 +135,23 @@ class RecordTest < Minitest::Test
     assert_equal '[SRVRecord] _service._TCP.srv.dns-test.shopify.io. 60 IN SRV 10 47 80 target-srv.dns-test.shopify.io.', RECORD_FIXTURES[:srv].to_s
     assert_equal '[TXTRecord] txt.dns-test.shopify.io. 60 IN TXT "Hello, world!"', RECORD_FIXTURES[:txt].to_s
     assert_equal '[SPFRecord] dns-test.shopify.io. 3600 IN SPF "v=spf1 -all"', RECORD_FIXTURES[:spf].to_s
+  end
+
+  def test_txt_record_with_embedded_whitespace
+    record = Record::TXT.new(fqdn: 'example.com.', ttl: 600, txtdata: 'embedded whitespace')
+
+    assert_predicate record, :valid?
+    assert_equal 'embedded whitespace', record.txtdata
+    assert_equal '"embedded whitespace"', record.rdata_txt
+    assert_equal '[TXTRecord] example.com. 600 IN TXT "embedded whitespace"', record.to_s
+  end
+
+  def test_txt_record_with_embedded_quotes
+    record = Record::TXT.new(fqdn: 'example.com.', ttl: 600, txtdata: 'embedded "quotes"')
+
+    assert_predicate record, :valid?
+    assert_equal 'embedded "quotes"', record.txtdata
+    assert_equal '"embedded \"quotes\""', record.rdata_txt
+    assert_equal '[TXTRecord] example.com. 600 IN TXT "embedded \"quotes\""', record.to_s
   end
 end

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -122,7 +122,7 @@ class RecordTest < Minitest::Test
     assert_equal 'ns1.dynect.net.', RECORD_FIXTURES[:ns].rdata_txt
     assert_equal '10 47 80 target-srv.dns-test.shopify.io.', RECORD_FIXTURES[:srv].rdata_txt
     assert_equal '"Hello, world!"', RECORD_FIXTURES[:txt].rdata_txt
-    assert_equal 'v=spf1 -all', RECORD_FIXTURES[:spf].rdata_txt
+    assert_equal '"v=spf1 -all"', RECORD_FIXTURES[:spf].rdata_txt
   end
 
   def test_consistent_print_formatting

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -154,4 +154,20 @@ class RecordTest < Minitest::Test
     assert_equal '"embedded \"quotes\""', record.rdata_txt
     assert_equal '[TXTRecord] example.com. 600 IN TXT "embedded \"quotes\""', record.to_s
   end
+
+  def test_escape_quotes
+    assert_equal 'text with \"quotes\"', Record::TXT.escape('text with "quotes"')
+  end
+
+  def test_quote_value
+    assert_equal '"text with \"quotes\""', Record::TXT.quote('text with "quotes"')
+  end
+
+  def test_unescape_quotes
+    assert_equal 'text with "quotes"', Record::TXT.unescape('text with \"quotes\"')
+  end
+
+  def test_unquote_value
+    assert_equal 'text with "quotes"', Record::TXT.unquote('"text with \"quotes\""')
+  end
 end


### PR DESCRIPTION
this PR fixes #58

consistent handling of rdata for TXT records and escaping of `"` characters in strings
strip wrapping quotes from google API rdata

UPDATE: rebased after merging #55 #56 and #57