### PR TITLE
bump to version 5.0.5 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # CHANGELOG
 
-## 5.0.4
-- Replaces fog-dnsimple with dnsimple-ruby gem.
+## 5.0.5
+- Output progress messages for GoogleCloudDNS provider too. [BUGFIX]
+- Fix quoting/escaping for TXT records. [BUGFIX]
+- Make implementation-specific methods of Provider private. [REFACTOR]
+- DRY up SPF support to use TXT superclass implementation. [REFACTOR]
 
-## ¯\_(ツ)_/¯
+## 5.0.4
+- Replaces fog-dnsimple with dnsimple-ruby gem. [REFACTOR]
+
+## 5.0.0
+- Use DNSimple API v2 (via fog-dnsimple gem update).
+
+## 4.0.7
+
+- Fix issue updating records with same FQDN. [BUGFIX]

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.0.4'.freeze
+  VERSION = '5.0.5'.freeze
 end


### PR DESCRIPTION
from CHANGELOG...
```
- Output progress messages for GoogleCloudDNS provider too. [BUGFIX]
- Fix quoting/escaping for TXT records. [BUGFIX]
- Make implementation-specific methods of Provider private. [REFACTOR]
- DRY up SPF support to use TXT superclass implementation. [REFACTOR]
```