### PR TITLE
Use distinct Dynect sessions for each thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 5.1.0
+- use concurrent sessions when multi-threaded to avoid "This session already has a job running" errors. [BUGFIX]
+
 ## 5.0.5
 - Output progress messages for GoogleCloudDNS provider too. [BUGFIX]
 - Fix quoting/escaping for TXT records. [BUGFIX]
@@ -13,5 +16,4 @@
 - Use DNSimple API v2 (via fog-dnsimple gem update).
 
 ## 4.0.7
-
 - Fix issue updating records with same FQDN. [BUGFIX]

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -4,15 +4,15 @@ module RecordStore
   class Provider::DynECT < Provider
     class << self
       def freeze_zone(zone)
-        session.put_zone(zone, freeze: true)
+        synchronize { session.put_zone(zone, freeze: true) }
       end
 
       def thaw_zone(zone)
-        session.put_zone(zone, thaw: true)
+        synchronize { session.put_zone(zone, thaw: true) }
       end
 
       def publish(zone)
-        session.put_zone(zone, publish: true)
+        synchronize { session.put_zone(zone, publish: true) }
       end
 
       # Applies changeset to provider
@@ -30,7 +30,8 @@ module RecordStore
 
       # returns an array of Record objects that match the records which exist in the provider
       def retrieve_current_records(zone:, stdout: $stdout)
-        session.get_all_records(zone).body.fetch('data').flat_map do |type, records|
+        response = synchronize { session.get_all_records(zone) }
+        response.body.fetch('data').flat_map do |type, records|
           records.map do |record_body|
             begin
               build_from_api(record_body)
@@ -43,25 +44,25 @@ module RecordStore
 
       # Returns an array of the zones managed by provider as strings
       def zones
-        session.zones.map(&:domain)
+        synchronize { session.zones }.map(&:domain)
       end
 
       private
 
       def add(record, zone)
-        session.post_record(record.type, zone, record.fqdn, api_rdata(record), 'ttl' => record.ttl)
+        synchronize { session.post_record(record.type, zone, record.fqdn, api_rdata(record), 'ttl' => record.ttl) }
       end
 
       def remove(record, zone)
-        session.delete_record(record.type, zone, record.fqdn, record.id)
+        synchronize { session.delete_record(record.type, zone, record.fqdn, record.id) }
       end
 
       def update(id, record, zone)
-        session.put_record(record.type, zone, record.fqdn, api_rdata(record), 'ttl' => record.ttl, 'record_id' => id)
+        synchronize { session.put_record(record.type, zone, record.fqdn, api_rdata(record), 'ttl' => record.ttl, 'record_id' => id) }
       end
 
       def discard_change_set(zone)
-        session.request(expects: 200, method: :delete, path: "ZoneChanges/#{zone}")
+        synchronize { session.request(expects: 200, method: :delete, path: "ZoneChanges/#{zone}") }
       end
 
       def session
@@ -104,6 +105,11 @@ module RecordStore
         record[:fqdn] = "#{fqdn}." unless fqdn.ends_with?('.')
 
         Record.const_get(type).new(record)
+      end
+
+      def synchronize(&block)
+        @mutex ||= Mutex.new
+        @mutex.synchronize(&block)
       end
     end
   end

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.0.5'.freeze
+  VERSION = '5.1.0'.freeze
 end

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -50,13 +50,7 @@ module RecordStore
             current_zone = nil
             while not zones.empty?
               mutex.synchronize { current_zone = zones.shift }
-              begin
-                mutex.synchronize { modified_zones << current_zone } unless current_zone.unchanged?
-              rescue Excon::Error::BadRequest => e
-                raise e unless e.response.body.include?('session already has a job')
-                puts "DynECT session collision for #{current_zone.name}" if verbose
-                mutex.synchronize { zones.push(current_zone) }
-              end
+              mutex.synchronize { modified_zones << current_zone } unless current_zone.unchanged?
             end
           end
         end.each(&:join)


### PR DESCRIPTION
fog-dynect is not expecting to run with multiple threads sharing the dynect session, but that’s how record_store is using it

* fog-dynect issues a request and then if the response is  a 307 it polls the jobs api until the request is completed
* but… meanwhile another thread could have attempted to issue a request with the api

which means the code here... https://github.com/Shopify/record_store/blob/master/lib/record_store/zone.rb#L56
could cause us to thrash on the api

this PR attempts to address that by adding a mutex and syncronizing for exclusive session use