### PR TITLE
Add Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+cache: bundler
+language: ruby
+rvm:
+  - 2.3.1
+
+before_install:
+  - gem update --system
+  - gem --version
+
+before_script:
+  - bin/setup


### PR DESCRIPTION
Migrate CI to use Travis CI.

The build on this branch passes: https://travis-ci.org/Shopify/record_store/builds/395194124
