### PR TITLE
Update CI Ruby version to match dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 cache: bundler
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.4.3
 
 before_install:
   - gem update --system


### PR DESCRIPTION
Move up to Ruby 2.4.3 to match the version used in dev.