### PR TITLE
Add support for underscores in hostname CNAME entries

### DIFF
--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -1,7 +1,7 @@
 module RecordStore
   class Record
     FQDN_REGEX  = /\A(\*\.)?([a-z0-9_]+(-[a-z0-9]+)*\._?)+[a-z]{2,}\.\Z/i
-    CNAME_REGEX =  /\A(\*\.)?([a-z0-9]+((-|--)?[a-z0-9]+)*\._?)+[a-z]{2,}\.\Z/i
+    CNAME_REGEX =  /\A(\*\.)?([a-z0-9_]+((-|--)?[a-z0-9]+)*\._?)+[a-z]{2,}\.\Z/i
 
     include ActiveModel::Validations
 

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.1.0'.freeze
+  VERSION = '5.1.1'.freeze
 end

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -80,6 +80,7 @@ class RecordTest < Minitest::Test
     assert_predicate Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: 'example2.com'), :valid?
     assert_predicate Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: 'example-2.com'), :valid?
     assert_predicate Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: 'example--2.com'), :valid?
+    assert_predicate Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: '_example.com'), :valid?
     refute_predicate Record::CNAME.new(fqdn: 'samedomain.com', ttl: 3600, cname: 'samedomain.com'), :valid?
     refute_predicate Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: 'example---2.com'), :valid?
     refute_predicate Record::CNAME.new(fqdn: 'example.com', ttl: 3600, cname: '--2.com'), :valid?


### PR DESCRIPTION
AWS Certificate Manager leverages DNS CNAME entries to verify ownership of domains for certificate issuance as noted at https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-dns.html.  Although technically allowed, it is rare to see these in the hostname portion of CNAME entries.

@sbfaulkner @charlescng 