### PR TITLE
limit dynect api request rate

### DIFF
--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -1,4 +1,8 @@
 require 'fog/dynect'
+require 'limiter'
+
+Fog::DNS::Dynect::Real.extend Limiter::Mixin
+Fog::DNS::Dynect::Real.limit_method :request, rate: 5, interval: 1 # 5 RPS == 300 RPM
 
 module RecordStore
   class Provider::DynECT < Provider

--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'fog-dynect', '~> 0.2.0'
   spec.add_runtime_dependency 'dnsimple-ruby', '~> 2.0'
   spec.add_runtime_dependency 'google-cloud-dns'
+  spec.add_runtime_dependency 'ruby-limiter', '~> 1.0', '>= 1.0.1'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
use https://github.com/Shopify/limiter to restrict the dynect request rate

given that the gem has tests of its own... I'm not convinced there's a need for additional tests here (since existing tests work)

since I'm adding a GEM dependency, I think I may be more interested in getting y'all to review it before merging this... see: https://github.com/Shopify/limiter

wdyt @albiere ?