### PR TITLE
remove alias-points-to-root validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 5.2.1
+- remove alias at domain root validation
+
 ## 5.2.0
 - limit request rate for DynECT API to avoid 429 errors [FEATURE]
 

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.2.0'.freeze
+  VERSION = '5.2.1'.freeze
 end

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -15,7 +15,6 @@ module RecordStore
     validate :validate_same_ttl_for_records_sharing_fqdn_and_type
     validate :validate_provider_can_handle_zone_records
     validate :validate_can_handle_alias_records
-    validate :validate_alias_points_to_root
 
     class << self
       def download(name, provider_name, **write_options)

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -358,19 +358,6 @@ class ZoneTest < Minitest::Test
     assert_match /does not support ALIAS records/, invalid_zone.errors[:records].first
   end
 
-  def test_zone_validates_alias_points_to_root
-    valid_zone = Zone.new(name: 'matching-records.com', config: { providers: ['DynECT'], supports_alias: true }, records: [
-      { type: 'ALIAS', fqdn: 'matching-records.com', alias: 'matching-records.herokuapp.com', ttl: 60 },
-    ])
-    assert_predicate valid_zone, :valid?
-
-    invalid_zone = Zone.new(name: 'matching-records.com', config: { providers: ['DynECT'], supports_alias: true }, records: [
-      { type: 'ALIAS', fqdn: 'alias.matching-records.com', alias: 'matching-records.herokuapp.com', ttl: 60 },
-    ])
-    refute_predicate invalid_zone, :valid?
-    assert_equal 'ALIAS record should be defined on the root of the zone: [ALIASRecord] alias.matching-records.com. 60 IN ALIAS matching-records.herokuapp.com.', invalid_zone.errors[:records].first
-  end
-
   def test_modified_returns_all_zones_with_changes
     zone_a = Zone.find('one-record.com')
     zone_a.stubs(:build_changesets).returns([populated_changeset])


### PR DESCRIPTION
Removes validate_alias_points_to_root validation. ALIAS records are not only for apex root's.

ref: https://github.com/Shopify/record-store/pull/2484