### PR TITLE
Support dnsimple-4.5.0

### DIFF
--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -9,7 +9,7 @@ module RecordStore
 
       # returns an array of Record objects that match the records which exist in the provider
       def retrieve_current_records(zone:, stdout: $stdout)
-        session.zones.all_records(account_id, zone).data.map do |record|
+        session.zones.all_zone_records(account_id, zone).data.map do |record|
           begin
             build_from_api(record, zone)
           rescue StandardError
@@ -28,7 +28,7 @@ module RecordStore
 
       def add(record, zone)
         record_hash = api_hash(record, zone)
-        res = session.zones.create_record(account_id, zone, record_hash)
+        res = session.zones.create_zone_record(account_id, zone, record_hash)
 
         if record.type == 'ALIAS'
           txt_alias = retrieve_current_records(zone: zone).detect do |rr|
@@ -41,7 +41,7 @@ module RecordStore
       end
 
       def remove(record, zone)
-        session.zones.delete_record(account_id, zone, record.id)
+        session.zones.delete_zone_record(account_id, zone, record.id)
       end
 
       def update(id, record, zone)


### PR DESCRIPTION
- CI broke:
  - This PR will be in the record-store repo, so I should be able to trigger CI w/o issue and verify before merging (doing so manually because Github has turned off webhooks temporarily)
  - Seems like:
  `record_store --<depends on>--> dnsimple-ruby --<depends on>-- dnsimple >=2.0`
    I tested locally with a setup that had the   DNSimple 4.4.0 gem and it worked fine.  However, the DNSimple 4.5.0 gem changed a few method names, and is causing trouble in CI.

Will stop messing around with fork repos and create a branch here, and ensure that passes CI before merging.

Will try to get ... some gemspec dependency tightened up as a follow up.