### PR TITLE
Just use dnsimple directly

### DIFF
--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'fog-json'
   spec.add_runtime_dependency 'fog-xml'
   spec.add_runtime_dependency 'fog-dynect', '~> 0.2.0'
-  spec.add_runtime_dependency 'dnsimple-ruby', '~> 2.0'
+  spec.add_runtime_dependency 'dnsimple', '~> 4.4.0'
   spec.add_runtime_dependency 'google-cloud-dns'
   spec.add_runtime_dependency 'ruby-limiter', '~> 1.0', '>= 1.0.1'
 


### PR DESCRIPTION
dnsimple-ruby was renamed to dnsimple; this gives us an opportunity to depend on a specific version of dnsimple and workaround our issues on master.