### PR TITLE
fix tests for newer thor

### DIFF
--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0'
 
-  spec.add_runtime_dependency 'thor'
+  spec.add_runtime_dependency 'thor', '~> 0.20.3'
   spec.add_runtime_dependency 'activesupport', '>= 4.2'
   spec.add_runtime_dependency 'activemodel', '>= 4.2'
   spec.add_runtime_dependency 'ejson'

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -35,7 +35,7 @@ class CLITest < Minitest::Test
   def test_returns_nonzero_exit_status
     stderr = STDERR.clone
     STDERR.reopen(File::NULL, "w")
-    Thor.expects(:exit).with(1)
+    Thor.expects(:exit).with(false)
     RecordStore::CLI.start(%w(does not exist))
   ensure
     STDERR.reopen(stderr)


### PR DESCRIPTION
this PR fixes tests to work with newer Thor gem

older versions were passing the wrong type to `Kernel#exit`
