### PR TITLE
lowercase fqdns

### DIFF
--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -97,9 +97,8 @@ module RecordStore
           )
         end
 
-        unless record.fetch(:fqdn).ends_with?('.')
-          record[:fqdn] += '.'
-        end
+        fqdn = record.fetch(:fqdn)
+        record[:fqdn] = "#{fqdn}." unless fqdn.ends_with?('.')
 
         Record.const_get(record_type).new(record)
       end

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -64,11 +64,14 @@ module RecordStore
       end
 
       def build_from_api(api_record, zone)
+        fqdn = api_record.name.present? ? "#{api_record.name}.#{zone}" : zone
+        fqdn = "#{fqdn}." unless fqdn.ends_with?('.')
+
         record_type = api_record.type
         record = {
           record_id: api_record.id,
           ttl: api_record.ttl,
-          fqdn: api_record.name.present? ? "#{api_record.name}.#{zone}" : zone,
+          fqdn: fqdn.downcase,
         }
 
         return if record_type == 'SOA'
@@ -96,9 +99,6 @@ module RecordStore
             target: Record.ensure_ends_with_dot(host),
           )
         end
-
-        fqdn = record.fetch(:fqdn)
-        record[:fqdn] = "#{fqdn}." unless fqdn.ends_with?('.')
 
         Record.const_get(record_type).new(record)
       end

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -105,7 +105,8 @@ module RecordStore
         record[:txtdata] = Record::TXT.unescape(record[:txtdata]) if %w[SPF TXT].include?(type)
 
         fqdn = record.fetch(:fqdn)
-        record[:fqdn] = "#{fqdn}." unless fqdn.ends_with?('.')
+        fqdn = "#{fqdn}." unless fqdn.ends_with?('.')
+        record[:fqdn] = fqdn.downcase
 
         Record.const_get(type).new(record)
       end

--- a/lib/record_store/provider/google_cloud_dns.rb
+++ b/lib/record_store/provider/google_cloud_dns.rb
@@ -79,10 +79,13 @@ module RecordStore
       end
 
       def build_from_api(record)
+        fqdn = record.name.downcase
+        fqdn = "#{fqdn}." unless fqdn.ends_with?('.')
+
         record_params = {
           id: record.object_id,
           ttl: record.ttl,
-          fqdn: record.name,
+          fqdn: fqdn,
         }
 
         return if record.type == 'SOA'
@@ -109,10 +112,6 @@ module RecordStore
             port: port.to_i,
             target: target,
           )
-        end
-
-        unless record_params.fetch(:fqdn).ends_with?('.')
-          record_params[:fqdn] += '.'
         end
 
         Record.const_get(record.type).new(record_params)

--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -12,7 +12,7 @@ module RecordStore
     validate :validate_label_length
 
     def initialize(record)
-      @fqdn = Record.ensure_ends_with_dot(record.fetch(:fqdn))
+      @fqdn = Record.ensure_ends_with_dot(record.fetch(:fqdn)).downcase
       @ttl  = record.fetch(:ttl)
       @id   = record.fetch(:record_id, nil)
     end

--- a/test/dummy/zones/mixed-case-fqdn.com.yml
+++ b/test/dummy/zones/mixed-case-fqdn.com.yml
@@ -1,0 +1,12 @@
+mixed-case-fqdn.com:
+  config:
+    providers:
+    - DynECT
+    ignore_patterns:
+    - type: NS
+      fqdn: zone-file.com.
+  records:
+  - type: TXT
+    fqdn: Txt.mixed-case-fqdn.com.
+    ttl: 3600
+    txtdata: Value=Txt

--- a/test/dummy/zones/mixed-case-fqdn.com/TXT__Another.yml
+++ b/test/dummy/zones/mixed-case-fqdn.com/TXT__Another.yml
@@ -1,0 +1,2 @@
+ttl: 3600
+txtdata: Value=Another

--- a/test/providers/dnsimple_test.rb
+++ b/test/providers/dnsimple_test.rb
@@ -218,6 +218,29 @@ class DNSimpleTest < Minitest::Test
     assert_equal 60, record.ttl
   end
 
+  def test_build_txt_from_api_handles_mixed_case_fqdn
+    api_record = Dnsimple::Struct::ZoneRecord.new(
+      "id" => 5199689,
+      "domain_id" => 222002,
+      "parent_id" => nil,
+      "name" => "Txt",
+      "content" => "Hello, world!",
+      "ttl" => 60,
+      "priority" => nil,
+      "type" => "TXT",
+      "system_record" => false,
+      "created_at" => "2015-12-11T16:36:26.504Z",
+      "updated_at" => "2015-12-11T16:36:26.504Z"
+    )
+
+    record = @dnsimple.send(:build_from_api, api_record, @zone_name)
+
+    assert_kind_of Record::TXT, record
+    assert_equal 'txt.dns-scratch.me.', record.fqdn
+    assert_equal 'Hello, world!', record.txtdata
+    assert_equal 60, record.ttl
+  end
+
   def test_apply_changeset_sets_state_to_match_changeset
     a_record = Record::A.new(fqdn: 'test-record.dns-scratch.me.', ttl: 86400, address: '10.10.10.42')
 

--- a/test/providers/dnsimple_test.rb
+++ b/test/providers/dnsimple_test.rb
@@ -167,7 +167,7 @@ class DNSimpleTest < Minitest::Test
     record = @dnsimple.send(:build_from_api, api_record, @zone_name)
 
     assert_kind_of Record::SRV, record
-    assert_equal '_service._TCP.srv.dns-scratch.me.', record.fqdn
+    assert_equal '_service._tcp.srv.dns-scratch.me.', record.fqdn
     assert_equal 10, record.priority
     assert_equal 47, record.weight
     assert_equal 80, record.port

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -129,7 +129,7 @@ class DynECTTest < Minitest::Test
     })
 
     assert_kind_of Record::SRV, record
-    assert_equal '_service._TCP.srv.dns-test.shopify.io.', record.fqdn
+    assert_equal '_service._tcp.srv.dns-test.shopify.io.', record.fqdn
     assert_equal 10, record.priority
     assert_equal 47, record.weight
     assert_equal 80, record.port

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -175,6 +175,23 @@ class DynECTTest < Minitest::Test
     assert_equal 60, record.ttl
   end
 
+  def test_build_txt_from_api_handles_mixed_case_fqdn
+    record = Provider::DynECT.send(:build_from_api, {
+      "zone" => "dns-test.shopify.io",
+      "ttl" => 60,
+      "fqdn" => "Txt.dns-test.shopify.io",
+      "record_type" => "TXT",
+      "rdata" => {
+        "txtdata" => "Hello, world!",
+      },
+    })
+
+    assert_kind_of Record::TXT, record
+    assert_equal 'txt.dns-test.shopify.io.', record.fqdn
+    assert_equal 'Hello, world!', record.txtdata
+    assert_equal 60, record.ttl
+  end
+
   def test_apply_changeset_sets_state_to_match_changeset
     a_record = Record::A.new(fqdn: 'test-record.dns-test.shopify.io.', ttl: 86400, address: '10.10.10.42')
 

--- a/test/providers/google_cloud_dns_test.rb
+++ b/test/providers/google_cloud_dns_test.rb
@@ -101,7 +101,7 @@ class GoogleCloudDNSTest < Minitest::Test
     )
 
     assert_kind_of Record::SRV, record
-    assert_equal '_service._TCP.srv.dns-test.shopify.io.', record.fqdn
+    assert_equal '_service._tcp.srv.dns-test.shopify.io.', record.fqdn
     assert_equal 10, record.priority
     assert_equal 47, record.weight
     assert_equal 80, record.port

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -133,7 +133,7 @@ class RecordTest < Minitest::Test
     assert_equal '[CNAMERecord] cname.dns-test.shopify.io. 60 IN CNAME dns-test.shopify.io.', RECORD_FIXTURES[:cname].to_s
     assert_equal '[MXRecord] mx.dns-test.shopify.io. 60 IN MX 10 mail-server.example.com.', RECORD_FIXTURES[:mx].to_s
     assert_equal '[NSRecord] dns-test.shopify.io. 3600 IN NS ns1.dynect.net.', RECORD_FIXTURES[:ns].to_s
-    assert_equal '[SRVRecord] _service._TCP.srv.dns-test.shopify.io. 60 IN SRV 10 47 80 target-srv.dns-test.shopify.io.', RECORD_FIXTURES[:srv].to_s
+    assert_equal '[SRVRecord] _service._tcp.srv.dns-test.shopify.io. 60 IN SRV 10 47 80 target-srv.dns-test.shopify.io.', RECORD_FIXTURES[:srv].to_s
     assert_equal '[TXTRecord] txt.dns-test.shopify.io. 60 IN TXT "Hello, world!"', RECORD_FIXTURES[:txt].to_s
     assert_equal '[SPFRecord] dns-test.shopify.io. 3600 IN SPF "v=spf1 -all"', RECORD_FIXTURES[:spf].to_s
   end

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -45,6 +45,20 @@ class RecordTest < Minitest::Test
     assert_equal 5, record.ttl
   end
 
+  def test_downcases_fqdn
+    yaml_snippet = <<-YAML
+      type: TXT
+      fqdn: LowerCase.example.com.
+      txtdata: Value=MixedCase
+      ttl: 5 # TTL times are in seconds
+    YAML
+
+    record = Record.build_from_yaml_definition(YAML.load(yaml_snippet).symbolize_keys)
+
+    assert_kind_of Record::TXT, record
+    assert_equal 'lowercase.example.com.', record.fqdn
+  end
+
   def test_validates_txt
     assert_predicate Record::TXT.new(fqdn: "_dmarc.example.com.", ttl: 600, txtdata: 'whatever'), :valid?
     assert_predicate Record::A.new(fqdn: "example.com.", ttl: 600, address: '10.11.12.13'), :valid?

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -412,6 +412,15 @@ class ZoneTest < Minitest::Test
     assert_equal zone_a, modified_zones[0]
   end
 
+  def test_zone_downcases_fqdn
+    zone = Zone.find('mixed-case-fqdn.com')
+
+    assert_equal 2, zone.records.size
+
+    fqdns = zone.records.map(&:fqdn)
+    assert_equal fqdns.map(&:downcase), fqdns
+  end
+
   private
 
   def valid_zone_from_records(name, records:)


### PR DESCRIPTION
BACKGROUND:
* DNS is case-insenstive
* record-store is (was?) case sensitive
* DNSimple does not allow creation of DNS records with Mixed-Case fqdns
* DNSimple did support it at some point in history (we have some existing ones)
* Dynect supports creation of DNS records with Mixed-Case fqdns
* Dynect creates DNS records with "sticky" case - ie. once created in Mixed-Case it will always be mixed-case, even if DELETED, PUBLISHED and RE-CREATED

This set of conditions lead to being able to create a zone definition which attempts to create a mixed-case DNS record, but that immediately diverges state (or is considered to have diverged)

this PR downcases the fqdn...

1. when loading from API
2. when loading from YAML

the end result will be to...

1. always create DNS records with lower-case fqdns
2. treat all existing DNS records as if they were lower-case
