### PR TITLE
version 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 5.3.0
+- case insensitivity for fqns (force to lowercsase) [FEATURE]
+
 ## 5.2.2
 - support regex based ignore patterns [FEATURE]
 

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.2.2'.freeze
+  VERSION = '5.3.0'.freeze
 end


### PR DESCRIPTION
bump to version 5.3.0

implements "case insensitivity" through lowercase for better support across DNS providers