### PR TITLE
use Dyn API version 3.7.13 which actually supports CAA records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 
+## 5.4.2
+- use Dyn API version 3.7.13 (instead of 3.7.0) to get CAA support [BUGFIX]
+
 ## 5.4.1
-- case-insensitivity for CAA value validation [FEATURE]
+- case-insensitivity for CAA value validation [BUGFIX]
 
 ## 5.4.0
 - add support for CAA records [FEATURE]

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -3,6 +3,7 @@ require 'limiter'
 
 Fog::DNS::Dynect::Real.extend Limiter::Mixin
 Fog::DNS::Dynect::Real.limit_method :request, rate: 5, interval: 1 # 5 RPS == 300 RPM
+Fog::DNS::Dynect.recognizes :version # so it doesn't warn about unsupported (but actually supported) version option
 
 module RecordStore
   class Provider::DynECT < Provider
@@ -78,7 +79,8 @@ module RecordStore
           dynect_customer: secrets.fetch('customer'),
           dynect_username: secrets.fetch('username'),
           dynect_password: secrets.fetch('password'),
-          job_poll_timeout: 20
+          job_poll_timeout: 20,
+          version: '3.7.13',
         }
       end
 

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.4.1'.freeze
+  VERSION = '5.4.2'.freeze
 end


### PR DESCRIPTION
`fog-dynect` is locked to Dyn API version `3.7.0`

CAA support was not added until `3.7.6` (see https://manage.dynect.net/help/changelog.html)

This PR explicitly specifies the API version to use, overriding the version fog-dynect specifies