### PR TITLE
fog-dynect update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 5.4.3
+- use fog-dynect 0.4.0 to avoid version override [REFACTOR]
+
 ## 5.4.2
 - use Dyn API version 3.7.13 (instead of 3.7.0) to get CAA support [BUGFIX]
 

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -3,7 +3,6 @@ require 'limiter'
 
 Fog::DNS::Dynect::Real.extend Limiter::Mixin
 Fog::DNS::Dynect::Real.limit_method :request, rate: 5, interval: 1 # 5 RPS == 300 RPM
-Fog::DNS::Dynect.recognizes :version # so it doesn't warn about unsupported (but actually supported) version option
 
 module RecordStore
   class Provider::DynECT < Provider
@@ -80,7 +79,6 @@ module RecordStore
           dynect_username: secrets.fetch('username'),
           dynect_password: secrets.fetch('password'),
           job_poll_timeout: 20,
-          version: '3.7.13',
         }
       end
 

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.4.2'.freeze
+  VERSION = '5.4.3'.freeze
 end

--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'fog', '>= 1.33.0'
   spec.add_runtime_dependency 'fog-json'
   spec.add_runtime_dependency 'fog-xml'
-  spec.add_runtime_dependency 'fog-dynect', '~> 0.2.0'
+  spec.add_runtime_dependency 'fog-dynect', '~> 0.4.0'
   spec.add_runtime_dependency 'dnsimple', '~> 4.4.0'
   spec.add_runtime_dependency 'google-cloud-dns'
   spec.add_runtime_dependency 'ruby-limiter', '~> 1.0', '>= 1.0.1'

--- a/test/fixtures/vcr_cassettes/dynect_apply_changeset.yml
+++ b/test/fixtures/vcr_cassettes/dynect_apply_changeset.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api-v4.dynect.net/REST/Session
+    uri: https://api.dynect.net/REST/Session
     body:
       encoding: UTF-8
       string: '{"customer_name":"dynect_customer","user_name":"<DYNECT_USERNAME>","password":"<DYNECT_PASSWORD>"}'
@@ -35,7 +35,7 @@ http_interactions:
   recorded_at: Fri, 06 Nov 2015 20:01:07 GMT
 - request:
     method: put
-    uri: https://api-v4.dynect.net/REST/Zone/dns-test.shopify.io
+    uri: https://api.dynect.net/REST/Zone/dns-test.shopify.io
     body:
       encoding: UTF-8
       string: '{"thaw":true}'
@@ -70,7 +70,7 @@ http_interactions:
   recorded_at: Fri, 06 Nov 2015 20:01:08 GMT
 - request:
     method: post
-    uri: https://api-v4.dynect.net/REST/ARecord/dns-test.shopify.io/test-record.dns-test.shopify.io.
+    uri: https://api.dynect.net/REST/ARecord/dns-test.shopify.io/test-record.dns-test.shopify.io.
     body:
       encoding: UTF-8
       string: '{"ttl":86400,"rdata":{"address":"10.10.10.42"}}'
@@ -108,7 +108,7 @@ http_interactions:
   recorded_at: Fri, 06 Nov 2015 20:01:09 GMT
 - request:
     method: put
-    uri: https://api-v4.dynect.net/REST/Zone/dns-test.shopify.io
+    uri: https://api.dynect.net/REST/Zone/dns-test.shopify.io
     body:
       encoding: UTF-8
       string: '{"publish":true}'
@@ -145,7 +145,7 @@ http_interactions:
   recorded_at: Fri, 06 Nov 2015 20:01:10 GMT
 - request:
     method: put
-    uri: https://api-v4.dynect.net/REST/Zone/dns-test.shopify.io
+    uri: https://api.dynect.net/REST/Zone/dns-test.shopify.io
     body:
       encoding: UTF-8
       string: '{"freeze":true}'

--- a/test/fixtures/vcr_cassettes/dynect_apply_changeset_update.yml
+++ b/test/fixtures/vcr_cassettes/dynect_apply_changeset_update.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api-v4.dynect.net/REST/Session
+    uri: https://api.dynect.net/REST/Session
     body:
       encoding: UTF-8
       string: '{"customer_name":"dynect_customer","user_name":"<DYNECT_USERNAME>","password":"<DYNECT_PASSWORD>"}'
@@ -35,7 +35,7 @@ http_interactions:
   recorded_at: Fri, 06 Nov 2015 20:01:07 GMT
 - request:
     method: put
-    uri: https://api-v4.dynect.net/REST/Zone/dns-test.shopify.io
+    uri: https://api.dynect.net/REST/Zone/dns-test.shopify.io
     body:
       encoding: UTF-8
       string: '{"thaw":true}'
@@ -70,7 +70,7 @@ http_interactions:
   recorded_at: Fri, 06 Nov 2015 20:01:08 GMT
 - request:
     method: put
-    uri: https://api-v4.dynect.net/REST/TXTRecord/dns-test.shopify.io/test-record.dns-test.shopify.io./12345678
+    uri: https://api.dynect.net/REST/TXTRecord/dns-test.shopify.io/test-record.dns-test.shopify.io./12345678
     body:
       encoding: UTF-8
       string: '{"ttl":3600,"rdata":{"txtdata":"update"}}'
@@ -107,7 +107,7 @@ http_interactions:
   recorded_at: Fri, 06 Nov 2015 20:01:09 GMT
 - request:
     method: put
-    uri: https://api-v4.dynect.net/REST/Zone/dns-test.shopify.io
+    uri: https://api.dynect.net/REST/Zone/dns-test.shopify.io
     body:
       encoding: UTF-8
       string: '{"publish":true}'
@@ -144,7 +144,7 @@ http_interactions:
   recorded_at: Fri, 06 Nov 2015 20:01:10 GMT
 - request:
     method: put
-    uri: https://api-v4.dynect.net/REST/Zone/dns-test.shopify.io
+    uri: https://api.dynect.net/REST/Zone/dns-test.shopify.io
     body:
       encoding: UTF-8
       string: '{"freeze":true}'

--- a/test/fixtures/vcr_cassettes/dynect_retrieve_current_records.yml
+++ b/test/fixtures/vcr_cassettes/dynect_retrieve_current_records.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api-v4.dynect.net/REST/Session
+    uri: https://api.dynect.net/REST/Session
     body:
       encoding: UTF-8
       string: '{"customer_name":"dynect_customer","user_name":"<DYNECT_USERNAME>","password":"<DYNECT_PASSWORD>"}'
@@ -35,7 +35,7 @@ http_interactions:
   recorded_at: Fri, 06 Nov 2015 20:01:11 GMT
 - request:
     method: get
-    uri: https://api-v4.dynect.net/REST/AllRecord/dns-test.shopify.io?detail=Y
+    uri: https://api.dynect.net/REST/AllRecord/dns-test.shopify.io?detail=Y
     body:
       encoding: US-ASCII
       string: ''

--- a/test/fixtures/vcr_cassettes/dynect_retrieve_current_records_no_alias.yml
+++ b/test/fixtures/vcr_cassettes/dynect_retrieve_current_records_no_alias.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api-v4.dynect.net/REST/Session
+    uri: https://api.dynect.net/REST/Session
     body:
       encoding: UTF-8
       string: '{"customer_name":"dynect_customer","user_name":"<DYNECT_USERNAME>","password":"<DYNECT_PASSWORD>"}'
@@ -35,7 +35,7 @@ http_interactions:
   recorded_at: Fri, 06 Nov 2015 20:01:11 GMT
 - request:
     method: get
-    uri: https://api-v4.dynect.net/REST/AllRecord/dns-test.shopify.io?detail=Y
+    uri: https://api.dynect.net/REST/AllRecord/dns-test.shopify.io?detail=Y
     body:
       encoding: US-ASCII
       string: ''

--- a/test/fixtures/vcr_cassettes/dynect_zones.yml
+++ b/test/fixtures/vcr_cassettes/dynect_zones.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api-v4.dynect.net/REST/Session
+    uri: https://api.dynect.net/REST/Session
     body:
       encoding: UTF-8
       string: '{"customer_name":"dynect_customer","user_name":"<DYNECT_USERNAME>","password":"<DYNECT_PASSWORD>"}'
@@ -35,7 +35,7 @@ http_interactions:
   recorded_at: Fri, 06 Nov 2015 20:01:06 GMT
 - request:
     method: get
-    uri: https://api-v4.dynect.net/REST/Zone
+    uri: https://api.dynect.net/REST/Zone
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
This PR updates record_store to use fog-dynect 0.4.0 instead of overriding the Dyn API version as was previously done in #79
