### PR TITLE
Style: trailing comma in array literal

### DIFF
--- a/test/changeset_test.rb
+++ b/test/changeset_test.rb
@@ -207,7 +207,7 @@ class ChangesetTest < Minitest::Test
         fqdn: 'dns-scratch.me',
         nsdname: 'ns1.dnsimple.com.',
         record_id: 4
-      )
+      ),
     ]
     desired_records = current_records.map(&:dup)
 
@@ -223,7 +223,7 @@ class ChangesetTest < Minitest::Test
         fqdn: 'ns-test.dns-scratch.me',
         nsdname: 'ns2.dnsimple.com.',
         record_id: 6
-      )
+      ),
     ]
 
     # Swapped order is important here
@@ -237,7 +237,7 @@ class ChangesetTest < Minitest::Test
         ttl: 600,
         fqdn: 'ns-test.dns-scratch.me',
         nsdname: 'ns1.dnsimple.com.',
-      )
+      ),
     ]
 
     changeset = Changeset.new(

--- a/test/providers/google_cloud_dns_test.rb
+++ b/test/providers/google_cloud_dns_test.rb
@@ -258,7 +258,7 @@ class GoogleCloudDNSTest < Minitest::Test
         ttl: 86400,
         fqdn: 'www.dns-scratch.me',
         address: '1.2.3.4',
-      )
+      ),
     ].sort_by(&:to_s)
 
     VCR.use_cassette 'gcloud_dns_retrieve_current_records' do

--- a/test/providers/ns1_test.rb
+++ b/test/providers/ns1_test.rb
@@ -29,7 +29,7 @@ class NS1Test < Minitest::Test
   def test_add_multiple_changesets
     records = [
       Record::A.new(fqdn: 'test_add_multiple_changesets.test.recordstore.io', ttl: 600, address: '10.10.10.42'),
-      Record::A.new(fqdn: 'test_add_multiple_changesets.test.recordstore.io', ttl: 600, address: '10.10.10.43')
+      Record::A.new(fqdn: 'test_add_multiple_changesets.test.recordstore.io', ttl: 600, address: '10.10.10.43'),
     ]
 
     VCR.use_cassette 'ns1_add_multiple_changesets' do
@@ -489,7 +489,7 @@ class NS1Test < Minitest::Test
   def test_remove_record_should_not_remove_all_records_for_fqdn
     record_1, record_2 = [
       Record::A.new(fqdn: 'one_of_these_should_remain.test.recordstore.io', ttl: 600, address: '10.10.10.42'),
-      Record::A.new(fqdn: 'one_of_these_should_remain.test.recordstore.io', ttl: 600, address: '10.10.10.43')
+      Record::A.new(fqdn: 'one_of_these_should_remain.test.recordstore.io', ttl: 600, address: '10.10.10.43'),
     ]
 
     VCR.use_cassette 'ns1_remove_record_should_not_remove_all_records_for_fqdn' do

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -181,23 +181,17 @@ class ZoneTest < Minitest::Test
     ]
 
     assert_equal 2, Zone.filter_records(records, []).length
-    assert_equal 1, Zone.filter_records(records, [
-      Zone::Config::IgnorePattern.new(type: 'CNAME')
-    ]).length
-    assert_equal 2, Zone.filter_records(records, [
-      Zone::Config::IgnorePattern.new(type: 'TXT')
-    ]).length
+    assert_equal 1, Zone.filter_records(records, [Zone::Config::IgnorePattern.new(type: 'CNAME')]).length
+    assert_equal 2, Zone.filter_records(records, [Zone::Config::IgnorePattern.new(type: 'TXT')]).length
     assert_equal 1, Zone.filter_records(records, [
       Zone::Config::IgnorePattern.new(type: 'TXT'),
-      Zone::Config::IgnorePattern.new(type: 'CNAME')
+      Zone::Config::IgnorePattern.new(type: 'CNAME'),
     ]).length
     assert_equal 0, Zone.filter_records(records, [
       Zone::Config::IgnorePattern.new(type: 'TXT'),
-      Zone::Config::IgnorePattern.new(ttl: 600)
+      Zone::Config::IgnorePattern.new(ttl: 600),
     ]).length
-    assert_equal 1, Zone.filter_records(records, [
-      Zone::Config::IgnorePattern.new(cname: 'real.example.com.')
-    ]).length
+    assert_equal 1, Zone.filter_records(records, [Zone::Config::IgnorePattern.new(cname: 'real.example.com.')]).length
   end
 
   def test_download_downloads_zone_into_file
@@ -223,7 +217,7 @@ class ZoneTest < Minitest::Test
             fqdn: 'test-record.dns-test.shopify.io',
             address: '10.10.10.10',
             record_id: 189358987
-          )
+          ),
         ], zone.records
       end
     end


### PR DESCRIPTION
Style: trailing comma in array literal

```ruby
assert_equal(
  1,
  Zone.filter_records(
    records,
    [
      Zone::Config::IgnorePattern.new(type: 'CNAME'),
    ],
  ).length,
)
```

I didn't go this way because it looks very different compared to a single line of assert.
But if it's much better, I can update it later! 👍 