### PR TITLE
Lint: ineffective access modifier

### DIFF
--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -86,16 +86,18 @@ module RecordStore
       "[#{type}Record] #{fqdn} #{ttl} IN #{type} #{rdata_txt}"
     end
 
-    protected
+    class << self
+      protected
 
-    def validate_label_length
-      unless fqdn.split('.').all? { |label| label.length <= 63 }
-        errors.add(:fqdn, "A label should be at most 63 characters")
+      def validate_label_length
+        unless fqdn.split('.').all? { |label| label.length <= 63 }
+          errors.add(:fqdn, "A label should be at most 63 characters")
+        end
       end
-    end
 
-    def self.ensure_ends_with_dot(fqdn)
-      fqdn.end_with?(".") ? fqdn : "#{fqdn}."
+      def self.ensure_ends_with_dot(fqdn)
+        fqdn.end_with?(".") ? fqdn : "#{fqdn}."
+      end
     end
   end
 end

--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -86,17 +86,15 @@ module RecordStore
       "[#{type}Record] #{fqdn} #{ttl} IN #{type} #{rdata_txt}"
     end
 
-    class << self
-      protected
+    def self.ensure_ends_with_dot(fqdn)
+      fqdn.end_with?(".") ? fqdn : "#{fqdn}."
+    end
 
-      def validate_label_length
-        unless fqdn.split('.').all? { |label| label.length <= 63 }
-          errors.add(:fqdn, "A label should be at most 63 characters")
-        end
-      end
+    protected
 
-      def self.ensure_ends_with_dot(fqdn)
-        fqdn.end_with?(".") ? fqdn : "#{fqdn}."
+    def validate_label_length
+      unless fqdn.split('.').all? { |label| label.length <= 63 }
+        errors.add(:fqdn, "A label should be at most 63 characters")
       end
     end
   end

--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -27,6 +27,10 @@ module RecordStore
       def unquote(value)
         unescape(value.sub(/\A"(.*)"\z/, '\1'))
       end
+
+      def ensure_ends_with_dot(fqdn)
+        fqdn.end_with?(".") ? fqdn : "#{fqdn}."
+      end
     end
 
     def initialize(record)
@@ -85,12 +89,6 @@ module RecordStore
     def to_s
       "[#{type}Record] #{fqdn} #{ttl} IN #{type} #{rdata_txt}"
     end
-
-    def self.ensure_ends_with_dot(fqdn)
-      fqdn.end_with?(".") ? fqdn : "#{fqdn}."
-    end
-
-    private_class_method :ensure_ends_with_dot
 
     protected
 

--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -90,6 +90,8 @@ module RecordStore
       fqdn.end_with?(".") ? fqdn : "#{fqdn}."
     end
 
+    private_class_method :method
+
     protected
 
     def validate_label_length

--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -90,7 +90,7 @@ module RecordStore
       fqdn.end_with?(".") ? fqdn : "#{fqdn}."
     end
 
-    private_class_method :method
+    private_class_method :ensure_ends_with_dot
 
     protected
 


### PR DESCRIPTION
Related to #84
 - protected access modifiers don't make singleton methods