### PR TITLE
Update README for Google Cloud DNS and NS1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ In addition, the `AliasService` permission is required to be able to read or wri
 
 For a breakdown of what each permission allows read through [DynECT's permissions guide](https://help.dyn.com/user-and-group-permissions/).
 
+### Google Cloud DNS
+
+In order to use Google Cloud DNS, you'll need to add the `Project ID` and `Service Account Credentials` to `secrets.json`. The `Service Account Credentials` is a JSON format file that you need to generate on Google Cloud Platform. You can find more details about the authentication from [here](https://googleapis.dev/ruby/google-cloud-dns/latest/file.AUTHENTICATION.html).
+
+### NS1
+
+To use NS1, you'll need the API key generated from `Account Settings` on NS1 website and add the key to `secrets.json`.
+
 ----
 
 # Architecture


### PR DESCRIPTION
**What's the problem?**

There's no information for `Google Cloud DNS` and `NS1` in `README.md`.

**How does this fix it?**

By adding guideline for them

**How will I ship?**

- Merge this PR
- Have shipit it

**How to rollback?**

Revert the PR

*Comment: Since I have no access to Google Cloud DNS, the update for Google Cloud DNS is based on the `secrets.json` and `documentation`.*