### PR TITLE
bump up the version to 5.7.0 with OCI library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+## 5.7.0
+- add OCI library as runtime dependency [FEATURE]
+
 ## 5.6.0
 - add OCI provider [FEATURE]
 

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.6.0'.freeze
+  VERSION = '5.7.0'.freeze
 end

--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'google-cloud-dns'
   spec.add_runtime_dependency 'ruby-limiter', '~> 1.0', '>= 1.0.1'
   spec.add_runtime_dependency 'ns1'
+  spec.add_runtime_dependency 'oci'
 
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake'
@@ -42,5 +43,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'oci'
 end

--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'google-cloud-dns'
   spec.add_runtime_dependency 'ruby-limiter', '~> 1.0', '>= 1.0.1'
   spec.add_runtime_dependency 'ns1'
-  spec.add_runtime_dependency 'oci'
+  spec.add_runtime_dependency 'oci', '~> 2.6.0'
 
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
**What's the problem?**

OCI library as runtime dependency was missing 

**How does this fix it?**

Adding OCI library to the runtime dependency 

**How will I ship?**

- Merge this PR
- Have shipit it
- Release next version

**How to rollback?**

Revert the PR
