### PR TITLE
Bump ruby dependency to 2.5.0

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@
 name: recordstore
 
 up:
-  - ruby: 2.4.3
+  - ruby: 2.5.0
   - bundler
 
 commands:


### PR DESCRIPTION
The currently matched version of `activesupport` appears to depend on Ruby 2.5.0.

On Ruby 2.4.3:

```
┃┃ Gem::RuntimeRequirementNotMetError: zeitwerk requires Ruby version >= 2.4.4. The current ruby version is 2.4.3.205.
┃┃ An error occurred while installing zeitwerk (2.2.1), and Bundler cannot continue.
┃┃ Make sure that `gem install zeitwerk -v '2.2.1' --source 'https://rubygems.org/'` succeeds before bundling.
┃┃ In Gemfile:
┃┃   record_store was resolved to 5.7.1, which depends on
┃┃     activemodel was resolved to 6.0.1, which depends on
┃┃       activesupport was resolved to 6.0.1, which depends on
┃┃         zeitwerk
┃
```

On Ruby 2.4.4:

```
┃┃ Gem::RuntimeRequirementNotMetError: activesupport requires Ruby version >= 2.5.0. The current ruby version is 2.4.4.296.
┃┃ An error occurred while installing activesupport (6.0.1), and Bundler cannot continue.
┃┃ Make sure that `gem install activesupport -v '6.0.1' --source 'https://rubygems.org/'` succeeds before bundling.
┃┃ In Gemfile:
┃┃   record_store was resolved to 5.7.1, which depends on
┃┃     activemodel was resolved to 6.0.1, which depends on
┃┃       activesupport
```