### PR TITLE
NS1: Generate resource record ids locally

### DIFF
--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -6,19 +6,21 @@ module RecordStore
     class Error < StandardError; end
 
     class ApiAnswer
-      def self.from_full_api_answer(type:, record_id:, answer:)
-        ApiAnswer.new(type: type, record_id: record_id, rrdata: answer["answer"])
-      end
-
-      def self.from_short_api_answer(type:, record_id:, answer:)
-        rrdata_fields = case type
-        when 'SPF', 'TXT'
-          [answer]
-        else
-          answer.split
+      class << self
+        def from_full_api_answer(type:, record_id:, answer:)
+          ApiAnswer.new(type: type, record_id: record_id, rrdata: answer["answer"])
         end
 
-        ApiAnswer.new(type: type, record_id: record_id, rrdata: rrdata_fields)
+        def from_short_api_answer(type:, record_id:, answer:)
+          rrdata_fields = case type
+          when 'SPF', 'TXT'
+            [answer]
+          else
+            answer.split
+          end
+
+          ApiAnswer.new(type: type, record_id: record_id, rrdata: rrdata_fields)
+        end
       end
 
       attr_accessor :type, :record_id, :rrdata

--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -36,7 +36,7 @@ module RecordStore
       end
 
       def id
-        [record_id, type, rrdata.join(':')].join(':')
+        [record_id, type, *rrdata]
       end
     end
 

--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -49,11 +49,9 @@ module RecordStore
       #
       # Returns: an array of `Record` for each record in the provider's zone
       def retrieve_current_records(zone:, stdout: $stdout) # rubocop:disable Lint/UnusedMethodArgument
-        records = records_for_zone(zone).map do |short_record|
-          build_from_api(short_record)
-        end
-
-        records.flatten.compact
+        records_for_zone(zone)
+          .flat_map { |short_record| build_from_api(short_record) }
+          .compact
       end
 
       # Returns an array of the zones managed by provider as strings

--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -47,16 +47,11 @@ module RecordStore
       #
       # Returns: an array of `Record` for each record in the provider's zone
       def retrieve_current_records(zone:, stdout: $stdout) # rubocop:disable Lint/UnusedMethodArgument
-        full_api_records = records_for_zone(zone).map do |short_record|
-          client.record(
-            zone: zone,
-            fqdn: short_record["domain"],
-            type: short_record["type"],
-            must_exist: true,
-          )
+        records = records_for_zone(zone).map do |short_record|
+          build_from_api(short_record)
         end
 
-        full_api_records.map { |r| build_from_api(r) }.flatten.compact
+        records.flatten.compact
       end
 
       # Returns an array of the zones managed by provider as strings
@@ -157,10 +152,17 @@ module RecordStore
 
         # Identify the answer in this record with the matching ID, and update it
         updated = false
-        existing_record["answers"].each do |answer|
-          next if answer["id"] != id
+        existing_record["answers"].each do |existing_answer|
+          existing_answer_id = ApiAnswer.from_full_api_answer(
+            record_id: existing_record['id'],
+            type: existing_record['type'],
+            answer: existing_answer,
+          ).id
+
+          next if existing_answer_id != id
+
           updated = true
-          answer["answer"] = build_api_answer_from_record(record)
+          existing_answer["answer"] = build_api_answer_from_record(record)
         end
 
         unless updated
@@ -183,21 +185,28 @@ module RecordStore
         record_type = api_record["type"]
         return if record_type == 'SOA'
 
-        api_record["answers"].map do |api_answer|
-          answer = api_answer["answer"]
+        answers = api_record["short_answers"].map do |raw_answer|
+          ApiAnswer.from_short_api_answer(
+            record_id: api_record['id'],
+            type: api_record['type'],
+            answer: raw_answer,
+          )
+        end
+
+        answers.map do |answer|
           record = {
             ttl: api_record["ttl"],
             fqdn: fqdn.downcase,
-            record_id: api_answer["id"],
+            record_id: answer.id,
           }
 
           case record_type
           when 'A', 'AAAA'
-            record.merge!(address: answer.first)
+            record.merge!(address: answer.rrdata_string)
           when 'ALIAS'
-            record.merge!(alias: answer.first)
+            record.merge!(alias: answer.rrdata_string)
           when 'CAA'
-            flags, tag, value = answer
+            flags, tag, value = answer.rrdata
 
             record.merge!(
               flags: flags.to_i,
@@ -205,21 +214,21 @@ module RecordStore
               value: Record.unquote(value),
             )
           when 'CNAME'
-            record.merge!(cname: answer.first)
+            record.merge!(cname: answer.rrdata_string)
           when 'MX'
 
-            preference, exchange = answer
+            preference, exchange = answer.rrdata
 
             record.merge!(
               preference: preference.to_i,
               exchange: exchange,
             )
           when 'NS'
-            record.merge!(nsdname: answer.first)
+            record.merge!(nsdname: answer.rrdata_string)
           when 'SPF', 'TXT'
-            record.merge!(txtdata: Record.unlong_quote(Record.unescape(answer.first).gsub(';', '\;')))
+            record.merge!(txtdata: Record.unlong_quote(Record.unescape(answer.rrdata_string).gsub(';', '\;')))
           when 'SRV'
-            priority, weight, port, host = answer
+            priority, weight, port, host = answer.rrdata
 
             record.merge!(
               priority: priority.to_i,

--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -8,7 +8,7 @@ module RecordStore
     class ApiAnswer
       class << self
         def from_full_api_answer(type:, record_id:, answer:)
-          ApiAnswer.new(type: type, record_id: record_id, rrdata: answer["answer"])
+          ApiAnswer.new(type: type, record_id: record_id, rrdata: answer['answer'])
         end
 
         def from_short_api_answer(type:, record_id:, answer:)
@@ -65,7 +65,7 @@ module RecordStore
 
       # Fetches simplified records for the provided zone
       def records_for_zone(zone)
-        client.zone(zone)["records"]
+        client.zone(zone)['records']
       end
 
       # Creates a new record to the zone. It is expected this call modifies external state.
@@ -154,7 +154,7 @@ module RecordStore
 
         # Identify the answer in this record with the matching ID, and update it
         updated = false
-        existing_record["answers"].each do |existing_answer|
+        existing_record['answers'].each do |existing_answer|
           existing_answer_id = ApiAnswer.from_full_api_answer(
             record_id: existing_record['id'],
             type: existing_record['type'],
@@ -164,7 +164,7 @@ module RecordStore
           next if existing_answer_id != id
 
           updated = true
-          existing_answer["answer"] = build_api_answer_from_record(record)
+          existing_answer['answer'] = build_api_answer_from_record(record)
         end
 
         unless updated
@@ -177,17 +177,17 @@ module RecordStore
           zone: zone,
           fqdn: record_fqdn,
           type: record.type,
-          params: { answers: existing_record["answers"], ttl: record.ttl }
+          params: { answers: existing_record['answers'], ttl: record.ttl }
         )
       end
 
       def build_from_api(api_record)
-        fqdn = Record.ensure_ends_with_dot(api_record["domain"])
+        fqdn = Record.ensure_ends_with_dot(api_record['domain'])
 
-        record_type = api_record["type"]
+        record_type = api_record['type']
         return if record_type == 'SOA'
 
-        answers = api_record["short_answers"].map do |raw_answer|
+        answers = api_record['short_answers'].map do |raw_answer|
           ApiAnswer.from_short_api_answer(
             record_id: api_record['id'],
             type: api_record['type'],
@@ -197,7 +197,7 @@ module RecordStore
 
         answers.map do |answer|
           record = {
-            ttl: api_record["ttl"],
+            ttl: api_record['ttl'],
             fqdn: fqdn.downcase,
             record_id: answer.id,
           }

--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -5,6 +5,39 @@ module RecordStore
   class Provider::NS1 < Provider
     class Error < StandardError; end
 
+    class ApiAnswer
+      def self.from_full_api_answer(type:, record_id:, answer:)
+        ApiAnswer.new(type: type, record_id: record_id, rrdata: answer["answer"])
+      end
+
+      def self.from_short_api_answer(type:, record_id:, answer:)
+        rrdata_fields = case type
+        when 'SPF', 'TXT'
+          [answer]
+        else
+          answer.split
+        end
+
+        ApiAnswer.new(type: type, record_id: record_id, rrdata: rrdata_fields)
+      end
+
+      attr_accessor :type, :record_id, :rrdata
+
+      def initialize(type:, record_id:, rrdata:)
+        @type = type
+        @record_id = record_id
+        @rrdata = rrdata
+      end
+
+      def rrdata_string
+        rrdata.join(' ')
+      end
+
+      def id
+        [record_id, type, rrdata.join(':')].join(':')
+      end
+    end
+
     class << self
       def client
         Provider::NS1::Client.new(api_key: secrets['api_key'])

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.7.1'.freeze
+  VERSION = '5.7.2'.freeze
 end

--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -43,4 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'minitest-focus'
 end

--- a/test/fixtures/vcr_cassettes/ns1_update_changeset_where_domain_doesnt_exist.yml
+++ b/test/fixtures/vcr_cassettes/ns1_update_changeset_where_domain_doesnt_exist.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 11 Nov 2019 18:00:37 GMT
+      - Fri, 22 Nov 2019 16:39:14 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -29,10 +29,10 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=ddec446f5c0597f491fe1081faa6e1ba71573495237; expires=Tue, 10-Nov-20
-        18:00:37 GMT; path=/; domain=.nsone.net; HttpOnly
+      - __cfduid=d14eb814416d783567c4a9996f516c36e1574440754; expires=Sun, 22-Dec-19
+        16:39:14 GMT; path=/; domain=.nsone.net; HttpOnly
       X-Ratelimit-Remaining:
-      - '894'
+      - '899'
       X-Ratelimit-By:
       - customer
       X-Ratelimit-Limit:
@@ -52,14 +52,14 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 53422ab2cf5dcab8-YYZ
+      - 539c5698d8a8cabc-YYZ
     body:
       encoding: UTF-8
       string: '{"message":"record not found"}
 
         '
     http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:37 GMT
+  recorded_at: Fri, 22 Nov 2019 16:39:00 GMT
 - request:
     method: put
     uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_update_changeset_where_domain_doesnt_exist.test.recordstore.io/A
@@ -83,7 +83,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 11 Nov 2019 18:00:37 GMT
+      - Fri, 22 Nov 2019 16:39:14 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -91,8 +91,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=df4eb72b18fb8c9f7c4a92ee9b9b2f4b01573495237; expires=Tue, 10-Nov-20
-        18:00:37 GMT; path=/; domain=.nsone.net; HttpOnly
+      - __cfduid=dc4af046d5915772e1cf5e06db92337b91574440754; expires=Sun, 22-Dec-19
+        16:39:14 GMT; path=/; domain=.nsone.net; HttpOnly
       X-Ratelimit-Remaining:
       - '99'
       X-Ratelimit-By:
@@ -123,14 +123,14 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 53422ab3badbab6a-YYZ
+      - 539c569bbfb2ab9a-YYZ
     body:
       encoding: ASCII-8BIT
-      string: '{"domain":"test_update_changeset_where_domain_doesnt_exist.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["10.10.10.48"],"id":"5dc9a1c5f2abd00001f13e2f"}],"id":"5dc9a1c5f2abd00001f13e30","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"A","networks":[0]}
+      string: '{"domain":"test_update_changeset_where_domain_doesnt_exist.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["10.10.10.48"],"id":"5dd80f32c94a900001e474d4"}],"id":"5dd80f32c94a900001e474d5","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"A","networks":[0]}
 
         '
     http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:37 GMT
+  recorded_at: Fri, 22 Nov 2019 16:39:01 GMT
 - request:
     method: get
     uri: https://api.nsone.net/v1/zones/test.recordstore.io
@@ -152,7 +152,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 11 Nov 2019 18:00:40 GMT
+      - Fri, 22 Nov 2019 16:39:17 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -160,12 +160,12 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d127e0d02cd72528202fe597706f5243f1573495240; expires=Tue, 10-Nov-20
-        18:00:40 GMT; path=/; domain=.nsone.net; HttpOnly
+      - __cfduid=da7abe68d841bab8241334980fc52dc561574440756; expires=Sun, 22-Dec-19
+        16:39:16 GMT; path=/; domain=.nsone.net; HttpOnly
       X-Ratelimit-Remaining:
       - '899'
       Etag:
-      - W/"6404850f04c75d5acfdd7e21ea8c2d15d2425940"
+      - W/"11a982fe7f792d7606dc06f9f2d0f6659df68f4b"
       X-Ratelimit-By:
       - customer
       X-Ratelimit-Limit:
@@ -194,513 +194,19 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 53422ac23a5bab6a-YYZ
+      - 539c56aadf40ca90-YYZ
     body:
       encoding: ASCII-8BIT
-      string: '{"nx_ttl":3600,"retry":7200,"dnssec":false,"zone":"test.recordstore.io","network_pools":["p04"],"serial":1573495237,"primary":{"enabled":false,"secondaries":[]},"refresh":43200,"expiry":1209600,"dns_servers":["dns1.p04.nsone.net","dns2.p04.nsone.net","dns3.p04.nsone.net","dns4.p04.nsone.net"],"records":[{"domain":"test.recordstore.io","short_answers":["dns1.p04.nsone.net","dns2.p04.nsone.net","dns3.p04.nsone.net","dns4.p04.nsone.net"],"ttl":3600,"tier":1,"type":"NS","id":"5dc9a15cc9c79d0001326a47"},{"domain":"test_add_a.test.recordstore.io","short_answers":["10.10.10.1"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dc9a1c2c9c79d00010da5ae"},{"domain":"test_add_changeset.test.recordstore.io","short_answers":["10.10.10.42"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dc9a1a4c94a9000011b3c23"},{"domain":"test_add_multiple_changesets.test.recordstore.io","short_answers":["10.10.10.42","10.10.10.43"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dc9a19cc9c79d0001326ac2"},{"domain":"test_add_ns.test.recordstore.io","short_answers":["test.recordstore.io."],"link":null,"ttl":600,"tier":1,"type":"NS","id":"5dc9a1b5bbccf900013b8bbc"},{"domain":"test_add_spf.test.recordstore.io","short_answers":["Hello
-        World!"],"link":null,"ttl":600,"tier":1,"type":"SPF","id":"5dc9a1a1403d5d0001f40219"},{"domain":"test_update_changeset_multiples.test.recordstore.io","short_answers":["10.10.10.50","10.10.10.48","10.10.10.49"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dc9a1a7403d5d0001fa4f51"},{"domain":"test_update_changeset_where_domain_doesnt_exist.test.recordstore.io","short_answers":["10.10.10.48"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dc9a1c5f2abd00001f13e30"}],"meta":{},"link":null,"primary_master":"dns1.p04.nsone.net","ttl":3600,"id":"5dc9a15cc9c79d0001326a42","hostmaster":"hostmaster@nsone.net","networks":[0],"pool":"p04"}
+      string: '{"nx_ttl":3600,"retry":7200,"dnssec":false,"zone":"test.recordstore.io","network_pools":["p04"],"serial":1574440754,"primary":{"enabled":false,"secondaries":[]},"refresh":43200,"expiry":1209600,"dns_servers":["dns1.p04.nsone.net","dns2.p04.nsone.net","dns3.p04.nsone.net","dns4.p04.nsone.net"],"records":[{"domain":"one_of_these_should_remain.test.recordstore.io","short_answers":["10.10.10.42","10.10.10.42","10.10.10.42"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dc9a200c94a9000011b3c94"},{"domain":"test.recordstore.io","short_answers":["dns1.p04.nsone.net","dns2.p04.nsone.net","dns3.p04.nsone.net","dns4.p04.nsone.net"],"ttl":3600,"tier":1,"type":"NS","id":"5dc9a15cc9c79d0001326a47"},{"domain":"test_add_a.test.recordstore.io","short_answers":["10.10.10.1","10.10.10.1","10.10.10.1"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dc9a1c2c9c79d00010da5ae"},{"domain":"test_add_alias.test.recordstore.io","short_answers":["10.10.10.1.","10.10.10.1.","10.10.10.1."],"link":null,"ttl":600,"tier":1,"type":"ALIAS","id":"5dc9a1d0bbccf9000186d1b1"},{"domain":"test_add_alias.test.recordstore.io","short_answers":["test.recordstore.io.","test.recordstore.io.","test.recordstore.io."],"link":null,"ttl":600,"tier":1,"type":"CNAME","id":"5dc9a1d6bbccf9000150da4d"},{"domain":"test_add_caa.test.recordstore.io","short_answers":["0
+        issue shopify.com","0 issue shopify.com","0 issue shopify.com"],"link":null,"ttl":600,"tier":1,"type":"CAA","id":"5dc9a1eac94a9000011b3c7b"},{"domain":"test_add_changeset.test.recordstore.io","short_answers":["10.10.10.42","10.10.10.42","10.10.10.42"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dc9a1a4c94a9000011b3c23"},{"domain":"test_add_multiple_changesets.test.recordstore.io","short_answers":["10.10.10.42","10.10.10.43","10.10.10.42","10.10.10.43","10.10.10.42","10.10.10.43"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dc9a19cc9c79d0001326ac2"},{"domain":"test_add_mx.test.recordstore.io","short_answers":["10
+        mxa.mailgun.org.","10 mxa.mailgun.org.","10 mxa.mailgun.org."],"link":null,"ttl":600,"tier":1,"type":"MX","id":"5dc9a1e5c94a9000014f6db5"},{"domain":"test_add_ns.test.recordstore.io","short_answers":["test.recordstore.io.","test.recordstore.io.","test.recordstore.io."],"link":null,"ttl":600,"tier":1,"type":"NS","id":"5dc9a1b5bbccf900013b8bbc"},{"domain":"test_add_spf.test.recordstore.io","short_answers":["Hello
+        World!","Hello World!","Hello World!"],"link":null,"ttl":600,"tier":1,"type":"SPF","id":"5dc9a1a1403d5d0001f40219"},{"domain":"test_add_spf.test.recordstore.io","short_answers":["1
+        2 3 spf.shopify.com.","1 2 3 spf.shopify.com.","1 2 3 spf.shopify.com."],"link":null,"ttl":600,"tier":1,"type":"SRV","id":"5dc9a1efbbccf9000186d1dd"},{"domain":"test_add_txt.test.recordstore.io","short_answers":["Hello
+        World!","Hello World!","Hello World!"],"link":null,"ttl":600,"tier":1,"type":"TXT","id":"5dc9a1ccc9c79d0001a966d1"},{"domain":"test_update_changeset.test.recordstore.io","short_answers":["10.10.10.49","10.10.10.49","10.10.10.49","10.10.10.49"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dc9a1f3f2abd00001a04de2"},{"domain":"test_update_changeset_multiples.test.recordstore.io","short_answers":["10.10.10.50","10.10.10.48","10.10.10.49","10.10.10.48","10.10.10.49","10.10.10.48","10.10.10.49"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dc9a1a7403d5d0001fa4f51"},{"domain":"test_update_changeset_where_domain_doesnt_exist.test.recordstore.io","short_answers":["10.10.10.48"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5dd80f32c94a900001e474d5"},{"domain":"test_updating_ttl.test.recordstore.io","short_answers":["10.10.10.1","10.10.10.1","10.10.10.1"],"link":null,"ttl":10,"tier":1,"type":"A","id":"5dc9a1dcf2abd00001a4abd5"}],"meta":{},"link":null,"primary_master":"dns1.p04.nsone.net","ttl":3600,"id":"5dc9a15cc9c79d0001326a42","hostmaster":"hostmaster@nsone.net","networks":[0],"pool":"p04"}
 
         '
     http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:40 GMT
-- request:
-    method: get
-    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test.recordstore.io/NS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Nsone-Key:
-      - "<NS1_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 11 Nov 2019 18:00:40 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=d875cb73043782856ca684129ca55f3a11573495240; expires=Tue, 10-Nov-20
-        18:00:40 GMT; path=/; domain=.nsone.net; HttpOnly
-      X-Ratelimit-Remaining:
-      - '898'
-      Etag:
-      - W/"2b57562c6d711d98ea8806432d7550b6cb6c3e1c"
-      X-Ratelimit-By:
-      - customer
-      X-Ratelimit-Limit:
-      - '900'
-      X-Ratelimit-Period:
-      - '300'
-      Pragma:
-      - no-cache
-      Cache-Control:
-      - no-cache
-      - private, max-age=0, no-cache, no-store
-      Expires:
-      - '0'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubdomains; preload
-      Cf-Cache-Status:
-      - DYNAMIC
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 53422ac39a2c3046-YYZ
-    body:
-      encoding: ASCII-8BIT
-      string: '{"domain":"test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":false,"answers":[{"answer":["dns1.p04.nsone.net"],"meta":{},"id":"5dc9a15cc9c79d0001326a43"},{"answer":["dns2.p04.nsone.net"],"meta":{},"id":"5dc9a15cc9c79d0001326a44"},{"answer":["dns3.p04.nsone.net"],"meta":{},"id":"5dc9a15cc9c79d0001326a45"},{"answer":["dns4.p04.nsone.net"],"meta":{},"id":"5dc9a15cc9c79d0001326a46"}],"id":"5dc9a15cc9c79d0001326a47","regions":{},"meta":{},"filters":[],"ttl":3600,"tier":1,"feeds":[],"type":"NS","networks":[0]}
-
-        '
-    http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:40 GMT
-- request:
-    method: get
-    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_add_a.test.recordstore.io/A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Nsone-Key:
-      - "<NS1_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 11 Nov 2019 18:00:40 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=d9558bea9d45a0ab82e243a8876572a9b1573495240; expires=Tue, 10-Nov-20
-        18:00:40 GMT; path=/; domain=.nsone.net; HttpOnly
-      X-Ratelimit-Remaining:
-      - '898'
-      Etag:
-      - W/"64806d563d0dc25bc05750a54e3079dc1442beb1"
-      X-Ratelimit-By:
-      - customer
-      X-Ratelimit-Limit:
-      - '900'
-      X-Ratelimit-Period:
-      - '300'
-      Pragma:
-      - no-cache
-      Cache-Control:
-      - no-cache
-      - private, max-age=0, no-cache, no-store
-      Expires:
-      - '0'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubdomains; preload
-      Cf-Cache-Status:
-      - DYNAMIC
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 53422ac48971ca98-YYZ
-    body:
-      encoding: ASCII-8BIT
-      string: '{"domain":"test_add_a.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["10.10.10.1"],"id":"5dc9a1c2c9c79d00010da5ad"}],"id":"5dc9a1c2c9c79d00010da5ae","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"A","networks":[0]}
-
-        '
-    http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:40 GMT
-- request:
-    method: get
-    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_add_changeset.test.recordstore.io/A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Nsone-Key:
-      - "<NS1_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 11 Nov 2019 18:00:40 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=df059c8f4c1309aa96d58faeaf0ba75a61573495240; expires=Tue, 10-Nov-20
-        18:00:40 GMT; path=/; domain=.nsone.net; HttpOnly
-      X-Ratelimit-Remaining:
-      - '897'
-      Etag:
-      - W/"c9f0990401ecbefe8a6690d90e743f4d41a8d8f6"
-      X-Ratelimit-By:
-      - customer
-      X-Ratelimit-Limit:
-      - '900'
-      X-Ratelimit-Period:
-      - '300'
-      Pragma:
-      - no-cache
-      Cache-Control:
-      - no-cache
-      - private, max-age=0, no-cache, no-store
-      Expires:
-      - '0'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubdomains; preload
-      Cf-Cache-Status:
-      - DYNAMIC
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 53422ac57bfecaa4-YYZ
-    body:
-      encoding: ASCII-8BIT
-      string: '{"domain":"test_add_changeset.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["10.10.10.42"],"id":"5dc9a1a4c94a9000011b3c22"}],"id":"5dc9a1a4c94a9000011b3c23","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"A","networks":[0]}
-
-        '
-    http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:40 GMT
-- request:
-    method: get
-    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_add_multiple_changesets.test.recordstore.io/A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Nsone-Key:
-      - "<NS1_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 11 Nov 2019 18:00:40 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=df6c2f3950c6b92e396b741e5b0aa4d551573495240; expires=Tue, 10-Nov-20
-        18:00:40 GMT; path=/; domain=.nsone.net; HttpOnly
-      X-Ratelimit-Remaining:
-      - '896'
-      Etag:
-      - W/"be0fffa7bd7fba04eed217992bf534868d46792c"
-      X-Ratelimit-By:
-      - customer
-      X-Ratelimit-Limit:
-      - '900'
-      X-Ratelimit-Period:
-      - '300'
-      Pragma:
-      - no-cache
-      Cache-Control:
-      - no-cache
-      - private, max-age=0, no-cache, no-store
-      Expires:
-      - '0'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubdomains; preload
-      Cf-Cache-Status:
-      - DYNAMIC
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 53422ac67bfeab94-YYZ
-    body:
-      encoding: ASCII-8BIT
-      string: '{"domain":"test_add_multiple_changesets.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["10.10.10.42"],"id":"5dc9a19cc9c79d0001326ac1"},{"answer":["10.10.10.43"],"id":"5dc9a19fc9c79d000145db5b"}],"id":"5dc9a19cc9c79d0001326ac2","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"A","networks":[0]}
-
-        '
-    http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:40 GMT
-- request:
-    method: get
-    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_add_ns.test.recordstore.io/NS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Nsone-Key:
-      - "<NS1_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 11 Nov 2019 18:00:40 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=d33dd43251d9cbe7e7b46042e1e27d0df1573495240; expires=Tue, 10-Nov-20
-        18:00:40 GMT; path=/; domain=.nsone.net; HttpOnly
-      X-Ratelimit-Remaining:
-      - '896'
-      Etag:
-      - W/"3be13f8b06c6fa6aea695193cd921834fda91651"
-      X-Ratelimit-By:
-      - customer
-      X-Ratelimit-Limit:
-      - '900'
-      X-Ratelimit-Period:
-      - '300'
-      Pragma:
-      - no-cache
-      Cache-Control:
-      - no-cache
-      - private, max-age=0, no-cache, no-store
-      Expires:
-      - '0'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubdomains; preload
-      Cf-Cache-Status:
-      - DYNAMIC
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 53422ac76e7827d2-YYZ
-    body:
-      encoding: ASCII-8BIT
-      string: '{"domain":"test_add_ns.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["test.recordstore.io."],"id":"5dc9a1b5bbccf900013b8bbb"}],"id":"5dc9a1b5bbccf900013b8bbc","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"NS","networks":[0]}
-
-        '
-    http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:40 GMT
-- request:
-    method: get
-    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_add_spf.test.recordstore.io/SPF
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Nsone-Key:
-      - "<NS1_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 11 Nov 2019 18:00:41 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=dc4f249c53869b7abcb19720559e6662c1573495241; expires=Tue, 10-Nov-20
-        18:00:41 GMT; path=/; domain=.nsone.net; HttpOnly
-      X-Ratelimit-Remaining:
-      - '895'
-      Etag:
-      - W/"b0c29cdb5c27b5ab209a3990eb1b2e5e9dcfc8fd"
-      X-Ratelimit-By:
-      - customer
-      X-Ratelimit-Limit:
-      - '900'
-      X-Ratelimit-Period:
-      - '300'
-      Pragma:
-      - no-cache
-      Cache-Control:
-      - no-cache
-      - private, max-age=0, no-cache, no-store
-      Expires:
-      - '0'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubdomains; preload
-      Cf-Cache-Status:
-      - DYNAMIC
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 53422ac84b9bcab8-YYZ
-    body:
-      encoding: ASCII-8BIT
-      string: '{"domain":"test_add_spf.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["Hello
-        World!"],"id":"5dc9a1a1403d5d0001f40218"}],"id":"5dc9a1a1403d5d0001f40219","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"SPF","networks":[0]}
-
-        '
-    http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:41 GMT
-- request:
-    method: get
-    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_update_changeset_multiples.test.recordstore.io/A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Nsone-Key:
-      - "<NS1_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 11 Nov 2019 18:00:41 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=d9093c4236bbdf2792799ea80251206811573495241; expires=Tue, 10-Nov-20
-        18:00:41 GMT; path=/; domain=.nsone.net; HttpOnly
-      X-Ratelimit-Remaining:
-      - '895'
-      Etag:
-      - W/"299ea05b4360b069b76850f4e2b96a0b5a8ff3d3"
-      X-Ratelimit-By:
-      - customer
-      X-Ratelimit-Limit:
-      - '900'
-      X-Ratelimit-Period:
-      - '300'
-      Pragma:
-      - no-cache
-      Cache-Control:
-      - no-cache
-      - private, max-age=0, no-cache, no-store
-      Expires:
-      - '0'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubdomains; preload
-      Cf-Cache-Status:
-      - DYNAMIC
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 53422ac95934ab4c-YYZ
-    body:
-      encoding: ASCII-8BIT
-      string: '{"domain":"test_update_changeset_multiples.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["10.10.10.50"],"id":"5dc9a1a7403d5d0001fa4f50"},{"answer":["10.10.10.48"],"id":"5dc9a1a9c94a9000011b3c29"},{"answer":["10.10.10.49"],"id":"5dc9a1abc94a900001044acf"}],"id":"5dc9a1a7403d5d0001fa4f51","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"A","networks":[0]}
-
-        '
-    http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:41 GMT
+  recorded_at: Fri, 22 Nov 2019 16:39:03 GMT
 - request:
     method: get
     uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_update_changeset_where_domain_doesnt_exist.test.recordstore.io/A
@@ -722,7 +228,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 11 Nov 2019 18:00:41 GMT
+      - Fri, 22 Nov 2019 16:39:17 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -730,12 +236,12 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d86c9d50e7297113e6626cc5b6835d4c01573495241; expires=Tue, 10-Nov-20
-        18:00:41 GMT; path=/; domain=.nsone.net; HttpOnly
+      - __cfduid=d0676b577e729c29e79520c6de3e18b471574440757; expires=Sun, 22-Dec-19
+        16:39:17 GMT; path=/; domain=.nsone.net; HttpOnly
       X-Ratelimit-Remaining:
-      - '894'
+      - '899'
       Etag:
-      - W/"1f20138d3940649346b3e79a08ee023db7a0fa8a"
+      - W/"1d2277e3f512f0a29d9c15ff100c4125b2cb1f25"
       X-Ratelimit-By:
       - customer
       X-Ratelimit-Limit:
@@ -764,85 +270,14 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 53422aca4881ca9c-YYZ
+      - 539c56ada850caa8-YYZ
     body:
       encoding: ASCII-8BIT
-      string: '{"domain":"test_update_changeset_where_domain_doesnt_exist.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["10.10.10.48"],"id":"5dc9a1c5f2abd00001f13e2f"}],"id":"5dc9a1c5f2abd00001f13e30","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"A","networks":[0]}
+      string: '{"domain":"test_update_changeset_where_domain_doesnt_exist.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["10.10.10.48"],"id":"5dd80f32c94a900001e474d4"}],"id":"5dd80f32c94a900001e474d5","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"A","networks":[0]}
 
         '
     http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:41 GMT
-- request:
-    method: get
-    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_update_changeset_where_domain_doesnt_exist.test.recordstore.io/A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Nsone-Key:
-      - "<NS1_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 11 Nov 2019 18:00:41 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=d8d340b7b3f2f6b739e02a3535f5b12121573495241; expires=Tue, 10-Nov-20
-        18:00:41 GMT; path=/; domain=.nsone.net; HttpOnly
-      X-Ratelimit-Remaining:
-      - '894'
-      Etag:
-      - W/"1f20138d3940649346b3e79a08ee023db7a0fa8a"
-      X-Ratelimit-By:
-      - customer
-      X-Ratelimit-Limit:
-      - '900'
-      X-Ratelimit-Period:
-      - '300'
-      Pragma:
-      - no-cache
-      Cache-Control:
-      - no-cache
-      - private, max-age=0, no-cache, no-store
-      Expires:
-      - '0'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubdomains; preload
-      Cf-Cache-Status:
-      - DYNAMIC
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 53422acb3d33cab4-YYZ
-    body:
-      encoding: ASCII-8BIT
-      string: '{"domain":"test_update_changeset_where_domain_doesnt_exist.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["10.10.10.48"],"id":"5dc9a1c5f2abd00001f13e2f"}],"id":"5dc9a1c5f2abd00001f13e30","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"A","networks":[0]}
-
-        '
-    http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:41 GMT
+  recorded_at: Fri, 22 Nov 2019 16:39:03 GMT
 - request:
     method: delete
     uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_update_changeset_where_domain_doesnt_exist.test.recordstore.io/A
@@ -864,7 +299,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 11 Nov 2019 18:00:41 GMT
+      - Fri, 22 Nov 2019 16:39:17 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -872,8 +307,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d880ee7f2817f290e8ba764fdd61f16521573495241; expires=Tue, 10-Nov-20
-        18:00:41 GMT; path=/; domain=.nsone.net; HttpOnly
+      - __cfduid=dc148caeb5db42c29b0c523811a592a821574440757; expires=Sun, 22-Dec-19
+        16:39:17 GMT; path=/; domain=.nsone.net; HttpOnly
       X-Ratelimit-Remaining:
       - '99'
       X-Ratelimit-By:
@@ -904,12 +339,12 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 53422acc2b25ab82-YYZ
+      - 539c56b07d1ccabc-YYZ
     body:
       encoding: UTF-8
       string: "{}\n"
     http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:41 GMT
+  recorded_at: Fri, 22 Nov 2019 16:39:04 GMT
 - request:
     method: get
     uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_update_changeset_where_domain_doesnt_exist.test.recordstore.io/A
@@ -931,7 +366,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 11 Nov 2019 18:00:43 GMT
+      - Fri, 22 Nov 2019 16:39:20 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -939,8 +374,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d2ca78053aa7518910eb6f15707c1530d1573495243; expires=Tue, 10-Nov-20
-        18:00:43 GMT; path=/; domain=.nsone.net; HttpOnly
+      - __cfduid=ddd6471815cc851e53e9d466845dd949e1574440759; expires=Sun, 22-Dec-19
+        16:39:19 GMT; path=/; domain=.nsone.net; HttpOnly
       X-Ratelimit-Remaining:
       - '899'
       X-Ratelimit-By:
@@ -962,12 +397,12 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 53422ad9de2dca90-YYZ
+      - 539c56bd8db4ab6a-YYZ
     body:
       encoding: UTF-8
       string: '{"message":"record not found"}
 
         '
     http_version: 
-  recorded_at: Mon, 11 Nov 2019 18:00:43 GMT
-recorded_with: VCR 5.0.0
+  recorded_at: Fri, 22 Nov 2019 16:39:06 GMT
+recorded_with: VCR 4.0.0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'minitest/autorun'
+require 'minitest/focus'
 require 'mocha/mini_test'
 require 'vcr'
 require 'pry'


### PR DESCRIPTION
**Problem**

Our current approach for fetching the resource records in a zone requires:

- A GET on the target zone.  The response contains a summary of the resource record sets contained in that zone.
  - These summaries missing `id`s for individual resource records.
- A GET on each resource recordset in the target zone to reveal resource records with `id`'s.
- All of these fetches are rate limited at 3rps.
- **Problem** Every record present in NS1 managed zones will slow down subsequent syncs by 0.3 seconds.

**How does this help?**

- We require resource records to be individually `id`'ed so we can compute zone updates in a provider agnostic way, then perform the actual updates across all providers using this `id`.
- As a workaround, this change will have `record_store` compute these `id` s as a digest of the details of each resource record.  Currently, the resource record set id, the resource record type and rrdata are used in the digest.  Since these `id`'s are only used within each `record_store` session, we can improve the digest in the future if there are any problems.