### PR TITLE
NS1: Escape colons on download, unescape colons on upload in TXT rdata

### DIFF
--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -245,7 +245,7 @@ module RecordStore
         if record.is_a?(Record::MX)
           [record.preference, record.exchange]
         elsif record.is_a?(Record::TXT) || record.is_a?(Record::SPF)
-          [Record.long_quote(record.txtdata)]
+          [Record.long_quote(record.txtdata).gsub('\;', ';')]
         elsif record.is_a?(Record::CAA)
           [record.flags, record.tag, record.value]
         elsif record.is_a?(Record::SRV)

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.7.2'.freeze
+  VERSION = '5.7.3'.freeze
 end

--- a/test/fixtures/vcr_cassettes/ns1_colons_always_escaped_when_exported_from_ns1.yml
+++ b/test/fixtures/vcr_cassettes/ns1_colons_always_escaped_when_exported_from_ns1.yml
@@ -1,0 +1,214 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_colons_always_escaped_when_exported.test.recordstore.io/TXT
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 05 Dec 2019 19:48:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '31'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d2704741edd71f2257f5a088adcd957ae1575575309; expires=Sat, 04-Jan-20
+        19:48:29 GMT; path=/; domain=.nsone.net; HttpOnly
+      X-Ratelimit-Remaining:
+      - '899'
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '900'
+      X-Ratelimit-Period:
+      - '300'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - '0'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 540889b23bcbf031-EWR
+    body:
+      encoding: UTF-8
+      string: '{"message":"record not found"}
+
+        '
+    http_version: 
+  recorded_at: Thu, 05 Dec 2019 19:48:28 GMT
+- request:
+    method: put
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_colons_always_escaped_when_exported.test.recordstore.io/TXT
+    body:
+      encoding: UTF-8
+      string: '{"answers":[{"answer":["v=DKIM; k=rsa;"]}],"ttl":60,"zone":"test.recordstore.io","domain":"test_colons_always_escaped_when_exported.test.recordstore.io","type":"TXT"}'
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Dec 2019 19:48:29 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dfc51df1f5b644514d1ab32ec3fd10bc91575575309; expires=Sat, 04-Jan-20
+        19:48:29 GMT; path=/; domain=.nsone.net; HttpOnly
+      X-Ratelimit-Remaining:
+      - '99'
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Period:
+      - '200'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      - private, max-age=0, no-cache, no-store
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 540889b50a2de768-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"domain":"test_colons_always_escaped_when_exported.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["v=DKIM;
+        k=rsa;"],"id":"5de95f0d403d5d00011ad560"}],"id":"5de95f0d403d5d00011ad561","regions":{},"meta":{},"link":null,"filters":[],"ttl":60,"tier":1,"type":"TXT","networks":[0]}
+
+        '
+    http_version: 
+  recorded_at: Thu, 05 Dec 2019 19:48:29 GMT
+- request:
+    method: get
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Dec 2019 19:48:32 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d7a57946c63eea8de2296303ddee751771575575312; expires=Sat, 04-Jan-20
+        19:48:32 GMT; path=/; domain=.nsone.net; HttpOnly
+      X-Ratelimit-Remaining:
+      - '899'
+      Etag:
+      - W/"b2aa29a918e08ad71a04bb56cd3d8bdcfa83c750"
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '900'
+      X-Ratelimit-Period:
+      - '300'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      - private, max-age=0, no-cache, no-store
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 540889c42f2e919e-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"nx_ttl":3600,"retry":7200,"zone":"test.recordstore.io","dnssec":false,"network_pools":["p04"],"serial":1575575309,"primary":{"enabled":false,"secondaries":[]},"refresh":43200,"expiry":1209600,"disabled":false,"records":[{"domain":"one_of_these_should_remain.test.recordstore.io","short_answers":["10.10.10.42"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82411c9c79d0001a4666f"},{"domain":"test.recordstore.io","short_answers":["dns1.p04.nsone.net","dns2.p04.nsone.net","dns3.p04.nsone.net","dns4.p04.nsone.net"],"ttl":3600,"tier":1,"type":"NS","id":"5de823a6c94a90000105473d"},{"domain":"test_add_a.test.recordstore.io","short_answers":["10.10.10.1"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82421bbccf900012e9e94"},{"domain":"test_add_alias.test.recordstore.io","short_answers":["10.10.10.1."],"link":null,"ttl":600,"tier":1,"type":"ALIAS","id":"5de8244fc9c79d0001a6d3fc"},{"domain":"test_add_alias.test.recordstore.io","short_answers":["test.recordstore.io."],"link":null,"ttl":600,"tier":1,"type":"CNAME","id":"5de82425403d5d00017b9e57"},{"domain":"test_add_caa.test.recordstore.io","short_answers":["0
+        issue shopify.com"],"link":null,"ttl":600,"tier":1,"type":"CAA","id":"5de82408c9c79d0001a6d3a6"},{"domain":"test_add_changeset.test.recordstore.io","short_answers":["10.10.10.42"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82441f2abd00001db803b"},{"domain":"test_add_multiple_changesets.test.recordstore.io","short_answers":["10.10.10.42","10.10.10.43"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de8241cbbccf900012e9e8f"},{"domain":"test_add_mx.test.recordstore.io","short_answers":["10
+        mxa.mailgun.org."],"link":null,"ttl":600,"tier":1,"type":"MX","id":"5de82418c9c79d0001a46675"},{"domain":"test_add_ns.test.recordstore.io","short_answers":["test.recordstore.io."],"link":null,"ttl":600,"tier":1,"type":"NS","id":"5de82435c94a9000013abda4"},{"domain":"test_add_spf.test.recordstore.io","short_answers":["Hello
+        World!"],"link":null,"ttl":600,"tier":1,"type":"SPF","id":"5de823fec9c79d0001a4665b"},{"domain":"test_add_spf.test.recordstore.io","short_answers":["1
+        2 3 spf.shopify.com."],"link":null,"ttl":600,"tier":1,"type":"SRV","id":"5de82428bbccf9000141b636"},{"domain":"test_add_txt.test.recordstore.io","short_answers":["Hello
+        World!"],"link":null,"ttl":600,"tier":1,"type":"TXT","id":"5de82438403d5d00011915cb"},{"domain":"test_colon_txt.test.recordstore.io","short_answers":["v=DKIM;
+        k=rsa;"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5de95d3c403d5d0001929456"},{"domain":"test_colon_txt_added.test.recordstore.io","short_answers":["v=DKIM;
+        k=rsa;"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5de95dbb403d5d00011ad341"},{"domain":"test_colons_always_escaped_when_exported.test.recordstore.io","short_answers":["v=DKIM;
+        k=rsa;"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5de95f0d403d5d00011ad561"},{"domain":"test_update_changeset.test.recordstore.io","short_answers":["10.10.10.49"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82401bbccf90001776648"},{"domain":"test_update_changeset_multiples.test.recordstore.io","short_answers":["10.10.10.50","10.10.10.48","10.10.10.49"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82444403d5d00017b9e7c"},{"domain":"test_updating_ttl.test.recordstore.io","short_answers":["10.10.10.1"],"link":null,"ttl":10,"tier":1,"type":"A","id":"5de8243bc94a900001d7e309"}],"meta":{},"link":null,"primary_master":"dns1.p04.nsone.net","ttl":3600,"id":"5de823a6c94a900001054738","dns_servers":["dns1.p04.nsone.net","dns2.p04.nsone.net","dns3.p04.nsone.net","dns4.p04.nsone.net"],"hostmaster":"hostmaster@nsone.net","networks":[0],"pool":"p04"}
+
+        '
+    http_version: 
+  recorded_at: Thu, 05 Dec 2019 19:48:31 GMT
+recorded_with: VCR 5.0.0

--- a/test/fixtures/vcr_cassettes/ns1_escaped_colons_maintained_when_exported_from_ns1.yml
+++ b/test/fixtures/vcr_cassettes/ns1_escaped_colons_maintained_when_exported_from_ns1.yml
@@ -1,0 +1,215 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_escaped_colons_maintained_when_exported.test.recordstore.io/TXT
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 05 Dec 2019 19:48:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '31'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=df5244ae6b4e2272c55ff5100ca037b5f1575575312; expires=Sat, 04-Jan-20
+        19:48:32 GMT; path=/; domain=.nsone.net; HttpOnly
+      X-Ratelimit-Remaining:
+      - '899'
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '900'
+      X-Ratelimit-Period:
+      - '300'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - '0'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 540889c7ee8fe83d-EWR
+    body:
+      encoding: UTF-8
+      string: '{"message":"record not found"}
+
+        '
+    http_version: 
+  recorded_at: Thu, 05 Dec 2019 19:48:32 GMT
+- request:
+    method: put
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_escaped_colons_maintained_when_exported.test.recordstore.io/TXT
+    body:
+      encoding: UTF-8
+      string: '{"answers":[{"answer":["v=DKIM; k=rsa;"]}],"ttl":60,"zone":"test.recordstore.io","domain":"test_escaped_colons_maintained_when_exported.test.recordstore.io","type":"TXT"}'
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Dec 2019 19:48:33 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d9d2ebfbcae06da8d2d7118535d97275f1575575313; expires=Sat, 04-Jan-20
+        19:48:33 GMT; path=/; domain=.nsone.net; HttpOnly
+      X-Ratelimit-Remaining:
+      - '99'
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Period:
+      - '200'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      - private, max-age=0, no-cache, no-store
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 540889cab890e6c4-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"domain":"test_escaped_colons_maintained_when_exported.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["v=DKIM;
+        k=rsa;"],"id":"5de95f11f2abd00001c9dbc9"}],"id":"5de95f11f2abd00001c9dbca","regions":{},"meta":{},"link":null,"filters":[],"ttl":60,"tier":1,"type":"TXT","networks":[0]}
+
+        '
+    http_version: 
+  recorded_at: Thu, 05 Dec 2019 19:48:32 GMT
+- request:
+    method: get
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Dec 2019 19:48:35 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d4b11c0e0a4f8a40437803a370d41d7151575575315; expires=Sat, 04-Jan-20
+        19:48:35 GMT; path=/; domain=.nsone.net; HttpOnly
+      X-Ratelimit-Remaining:
+      - '899'
+      Etag:
+      - W/"5ba21adde3a358439bf8c75c7f3e3c96a2c29301"
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '900'
+      X-Ratelimit-Period:
+      - '300'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      - private, max-age=0, no-cache, no-store
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 540889d92854c5f0-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"nx_ttl":3600,"retry":7200,"zone":"test.recordstore.io","dnssec":false,"network_pools":["p04"],"serial":1575575313,"primary":{"enabled":false,"secondaries":[]},"refresh":43200,"expiry":1209600,"disabled":false,"records":[{"domain":"one_of_these_should_remain.test.recordstore.io","short_answers":["10.10.10.42"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82411c9c79d0001a4666f"},{"domain":"test.recordstore.io","short_answers":["dns1.p04.nsone.net","dns2.p04.nsone.net","dns3.p04.nsone.net","dns4.p04.nsone.net"],"ttl":3600,"tier":1,"type":"NS","id":"5de823a6c94a90000105473d"},{"domain":"test_add_a.test.recordstore.io","short_answers":["10.10.10.1"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82421bbccf900012e9e94"},{"domain":"test_add_alias.test.recordstore.io","short_answers":["10.10.10.1."],"link":null,"ttl":600,"tier":1,"type":"ALIAS","id":"5de8244fc9c79d0001a6d3fc"},{"domain":"test_add_alias.test.recordstore.io","short_answers":["test.recordstore.io."],"link":null,"ttl":600,"tier":1,"type":"CNAME","id":"5de82425403d5d00017b9e57"},{"domain":"test_add_caa.test.recordstore.io","short_answers":["0
+        issue shopify.com"],"link":null,"ttl":600,"tier":1,"type":"CAA","id":"5de82408c9c79d0001a6d3a6"},{"domain":"test_add_changeset.test.recordstore.io","short_answers":["10.10.10.42"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82441f2abd00001db803b"},{"domain":"test_add_multiple_changesets.test.recordstore.io","short_answers":["10.10.10.42","10.10.10.43"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de8241cbbccf900012e9e8f"},{"domain":"test_add_mx.test.recordstore.io","short_answers":["10
+        mxa.mailgun.org."],"link":null,"ttl":600,"tier":1,"type":"MX","id":"5de82418c9c79d0001a46675"},{"domain":"test_add_ns.test.recordstore.io","short_answers":["test.recordstore.io."],"link":null,"ttl":600,"tier":1,"type":"NS","id":"5de82435c94a9000013abda4"},{"domain":"test_add_spf.test.recordstore.io","short_answers":["Hello
+        World!"],"link":null,"ttl":600,"tier":1,"type":"SPF","id":"5de823fec9c79d0001a4665b"},{"domain":"test_add_spf.test.recordstore.io","short_answers":["1
+        2 3 spf.shopify.com."],"link":null,"ttl":600,"tier":1,"type":"SRV","id":"5de82428bbccf9000141b636"},{"domain":"test_add_txt.test.recordstore.io","short_answers":["Hello
+        World!"],"link":null,"ttl":600,"tier":1,"type":"TXT","id":"5de82438403d5d00011915cb"},{"domain":"test_colon_txt.test.recordstore.io","short_answers":["v=DKIM;
+        k=rsa;"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5de95d3c403d5d0001929456"},{"domain":"test_colon_txt_added.test.recordstore.io","short_answers":["v=DKIM;
+        k=rsa;"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5de95dbb403d5d00011ad341"},{"domain":"test_colons_always_escaped_when_exported.test.recordstore.io","short_answers":["v=DKIM;
+        k=rsa;"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5de95f0d403d5d00011ad561"},{"domain":"test_escaped_colons_maintained_when_exported.test.recordstore.io","short_answers":["v=DKIM;
+        k=rsa;"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5de95f11f2abd00001c9dbca"},{"domain":"test_update_changeset.test.recordstore.io","short_answers":["10.10.10.49"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82401bbccf90001776648"},{"domain":"test_update_changeset_multiples.test.recordstore.io","short_answers":["10.10.10.50","10.10.10.48","10.10.10.49"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82444403d5d00017b9e7c"},{"domain":"test_updating_ttl.test.recordstore.io","short_answers":["10.10.10.1"],"link":null,"ttl":10,"tier":1,"type":"A","id":"5de8243bc94a900001d7e309"}],"meta":{},"link":null,"primary_master":"dns1.p04.nsone.net","ttl":3600,"id":"5de823a6c94a900001054738","dns_servers":["dns1.p04.nsone.net","dns2.p04.nsone.net","dns3.p04.nsone.net","dns4.p04.nsone.net"],"hostmaster":"hostmaster@nsone.net","networks":[0],"pool":"p04"}
+
+        '
+    http_version: 
+  recorded_at: Thu, 05 Dec 2019 19:48:34 GMT
+recorded_with: VCR 5.0.0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,6 +112,10 @@ class Minitest::Test
         auth_token.first
       end
     end
+
+    config.before_playback do |interaction|
+      interaction.response.headers['X-Ratelimit-Period'] = 0
+    end
   end
 
   def teardown


### PR DESCRIPTION
**What's the problem**

- If a `record_store` YML file contains text resource records with rrdata containing semi-colons, when these records are pushed to DNS providers:
  - Those colons (`;`) are POSTed to NS1 as escaped colons (`\;`).  This turns out to not be a problem.
  - **Problem**: During a subsequent diff, those records are considered to be out of sync, because of the difference in escaping.

**Why'd's it happen?**

The NS1 provider introduces escaping when loading records, but doesn't strip the escaping when records are POSTed.

**Why do providers escape semi-colons on GET?**

- Because the API of one of the providers, Dynect, returns records with escaped semi-colons.  All other providers seem to be following this pattern to provide the rest of `record_store` normalized data.
- Just in case anyone's storing those escaped records in marshalled Record `yml` files from when Dynect was the only show in town.  By ensuring that all semi-colons are escaped on GET, the internal representation of Records should be consistent across all providers, as well as from those YAML files.

**How does this fix the problem?**

- By simply un-escaping the semi-colons when records are written out to NS1.