### PR TITLE
Disable client subnet when creating ns1 zones

### DIFF
--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -86,7 +86,11 @@ module RecordStore
             zone: zone,
             fqdn: record_fqdn,
             type: record.type,
-            params: { answers: new_answers, ttl: record.ttl }
+            params: {
+              answers: new_answers,
+              ttl: record.ttl,
+              use_client_subnet: false, # only required for filter chains that are not supported by record_store
+            }
           )
           return
         end

--- a/test/fixtures/vcr_cassettes/ns1_test_new_records_have_edns_client_subnet_disabled.yml
+++ b/test/fixtures/vcr_cassettes/ns1_test_new_records_have_edns_client_subnet_disabled.yml
@@ -1,0 +1,228 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_new_records_have_edns_client_subnet_disabled.test.recordstore.io/TXT
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 20 Mar 2020 19:15:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '31'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d9e7855b73d2a3d706599a0f6a0f0ab251584731750; expires=Sun, 19-Apr-20
+        19:15:50 GMT; path=/; domain=.nsone.net; HttpOnly; SameSite=Lax
+      Cf-Ray:
+      - 5771c39fbb1ecab8-YYZ
+      Cache-Control:
+      - no-cache
+      Expires:
+      - '0'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Pragma:
+      - no-cache
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '900'
+      X-Ratelimit-Period:
+      - '300'
+      X-Ratelimit-Remaining:
+      - '899'
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+    body:
+      encoding: UTF-8
+      string: '{"message":"record not found"}
+
+        '
+    http_version: null
+  recorded_at: Fri, 20 Mar 2020 19:15:50 GMT
+- request:
+    method: put
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_new_records_have_edns_client_subnet_disabled.test.recordstore.io/TXT
+    body:
+      encoding: UTF-8
+      string: '{"answers":[{"answer":["Some answer"]}],"ttl":3600,"zone":"test.recordstore.io","domain":"test_new_records_have_edns_client_subnet_disabled.test.recordstore.io","type":"TXT","use_client_subnet":false}'
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 Mar 2020 19:15:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d3732395f39bb0aa1f0d6261f5c7a43dc1584731750; expires=Sun, 19-Apr-20
+        19:15:50 GMT; path=/; domain=.nsone.net; HttpOnly; SameSite=Lax
+      Cf-Ray:
+      - 5771c3a2a9eef995-YYZ
+      Cache-Control:
+      - no-cache, private, max-age=0, no-cache, no-store
+      Expires:
+      - Fri, 20 Mar 2020 19:15:50 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Content-Security-Policy:
+      - 'script-src blob: ''unsafe-inline'' ''unsafe-eval'' ''self'' *.nsone.net *.nsone.co
+        disutgh7q0ncc.cloudfront.net www.google-analytics.com ns1.com translate.google.com;
+        report-uri https://cspaudit.prod.ns1.dev'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Pragma:
+      - no-cache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Period:
+      - '200'
+      X-Ratelimit-Remaining:
+      - '99'
+      X-Xss-Protection:
+      - 1; mode=block
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"domain":"test_new_records_have_edns_client_subnet_disabled.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":false,"answers":[{"answer":["Some
+        answer"],"id":"5e751667373b4000953edcde"}],"id":"5e751667373b4000953edcdf","regions":{},"meta":{},"link":null,"filters":[],"ttl":3600,"tier":1,"type":"TXT","networks":[0]}
+
+        '
+    http_version: null
+  recorded_at: Fri, 20 Mar 2020 19:15:51 GMT
+- request:
+    method: get
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 Mar 2020 19:15:53 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d2629a6f3e5e5deb595bb897a30d3f3ab1584731753; expires=Sun, 19-Apr-20
+        19:15:53 GMT; path=/; domain=.nsone.net; HttpOnly; SameSite=Lax
+      Cf-Ray:
+      - 5771c3b12f3acac8-YYZ
+      Cache-Control:
+      - no-cache, private, max-age=0, no-cache, no-store
+      Etag:
+      - W/"a3339f4a83b0eb8a3e2a9d6eb198403c14dfc157"
+      Expires:
+      - Fri, 20 Mar 2020 19:15:52 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Content-Security-Policy:
+      - 'script-src blob: ''unsafe-inline'' ''unsafe-eval'' ''self'' *.nsone.net *.nsone.co
+        disutgh7q0ncc.cloudfront.net www.google-analytics.com ns1.com translate.google.com;
+        report-uri https://cspaudit.prod.ns1.dev'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Pragma:
+      - no-cache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '900'
+      X-Ratelimit-Period:
+      - '300'
+      X-Ratelimit-Remaining:
+      - '899'
+      X-Xss-Protection:
+      - 1; mode=block
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"nx_ttl":3600,"retry":7200,"zone":"test.recordstore.io","dnssec":false,"network_pools":["p06"],"serial":1584731751,"primary":{"enabled":false,"secondaries":[]},"refresh":43200,"expiry":1209600,"disabled":false,"records":[{"domain":"one_of_these_should_remain.test.recordstore.io","short_answers":["10.10.10.42"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82411c9c79d0001a4666f"},{"domain":"test.recordstore.io","short_answers":["dns1.p06.nsone.net","dns2.p06.nsone.net","dns3.p06.nsone.net","dns4.p06.nsone.net"],"link":null,"ttl":3600,"tier":1,"type":"NS","id":"5de823a6c94a90000105473d"},{"domain":"test_add_a.test.recordstore.io","short_answers":["10.10.10.1"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82421bbccf900012e9e94"},{"domain":"test_add_alias.test.recordstore.io","short_answers":["10.10.10.1."],"link":null,"ttl":600,"tier":1,"type":"ALIAS","id":"5de8244fc9c79d0001a6d3fc"},{"domain":"test_add_alias.test.recordstore.io","short_answers":["test.recordstore.io."],"link":null,"ttl":600,"tier":1,"type":"CNAME","id":"5de82425403d5d00017b9e57"},{"domain":"test_add_caa.test.recordstore.io","short_answers":["0
+        issue shopify.com"],"link":null,"ttl":600,"tier":1,"type":"CAA","id":"5de82408c9c79d0001a6d3a6"},{"domain":"test_add_changeset.test.recordstore.io","short_answers":["10.10.10.42"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82441f2abd00001db803b"},{"domain":"test_add_multiple_changesets.test.recordstore.io","short_answers":["10.10.10.42","10.10.10.43"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de8241cbbccf900012e9e8f"},{"domain":"test_add_mx.test.recordstore.io","short_answers":["10
+        mxa.mailgun.org."],"link":null,"ttl":600,"tier":1,"type":"MX","id":"5de82418c9c79d0001a46675"},{"domain":"test_add_ns.test.recordstore.io","short_answers":["test.recordstore.io."],"link":null,"ttl":600,"tier":1,"type":"NS","id":"5de82435c94a9000013abda4"},{"domain":"test_add_spf.test.recordstore.io","short_answers":["Hello
+        World!"],"link":null,"ttl":600,"tier":1,"type":"SPF","id":"5de823fec9c79d0001a4665b"},{"domain":"test_add_spf.test.recordstore.io","short_answers":["1
+        2 3 spf.shopify.com."],"link":null,"ttl":600,"tier":1,"type":"SRV","id":"5de82428bbccf9000141b636"},{"domain":"test_add_txt.test.recordstore.io","short_answers":["Hello
+        World!"],"link":null,"ttl":600,"tier":1,"type":"TXT","id":"5de82438403d5d00011915cb"},{"domain":"test_colon_txt.test.recordstore.io","short_answers":["v=DKIM;
+        k=rsa;"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5de95d3c403d5d0001929456"},{"domain":"test_colon_txt_added.test.recordstore.io","short_answers":["v=DKIM;
+        k=rsa;"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5de95dbb403d5d00011ad341"},{"domain":"test_colons_always_escaped_when_exported.test.recordstore.io","short_answers":["v=DKIM;
+        k=rsa;"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5de95f0d403d5d00011ad561"},{"domain":"test_escaped_colons_maintained_when_exported.test.recordstore.io","short_answers":["v=DKIM;
+        k=rsa;"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5de95f11f2abd00001c9dbca"},{"domain":"test_new_records_have_edns_client_subnet_disabled.test.recordstore.io","short_answers":["Some
+        answer"],"link":null,"ttl":3600,"tier":1,"type":"TXT","id":"5e751667373b4000953edcdf"},{"domain":"test_update_changeset.test.recordstore.io","short_answers":["10.10.10.49"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82401bbccf90001776648"},{"domain":"test_update_changeset_multiples.test.recordstore.io","short_answers":["10.10.10.50","10.10.10.48","10.10.10.49"],"link":null,"ttl":600,"tier":1,"type":"A","id":"5de82444403d5d00017b9e7c"},{"domain":"test_updating_ttl.test.recordstore.io","short_answers":["10.10.10.1"],"link":null,"ttl":10,"tier":1,"type":"A","id":"5de8243bc94a900001d7e309"},{"domain":"very_long_txt_record_more_than_255_chars.test.recordstore.io","short_answers":["0<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>567890<DNSIMPLE_ACCOUNT_ID>56789"],"link":null,"ttl":60,"tier":1,"type":"TXT","id":"5e5d3759f8d9f200861ece17"}],"meta":{},"link":null,"primary_master":"dns1.p06.nsone.net","ttl":3600,"id":"5de823a6c94a900001054738","dns_servers":["dns1.p06.nsone.net","dns2.p06.nsone.net","dns3.p06.nsone.net","dns4.p06.nsone.net"],"hostmaster":"hostmaster@nsone.net","networks":[0],"pool":"p06"}
+
+        '
+    http_version: null
+  recorded_at: Fri, 20 Mar 2020 19:15:53 GMT
+recorded_with: VCR 5.1.0

--- a/test/providers/ns1_test.rb
+++ b/test/providers/ns1_test.rb
@@ -628,4 +628,31 @@ class NS1Test < Minitest::Test
       assert_equal matching_records.first.txtdata, txtdata
     end
   end
+
+  def test_new_records_have_edns_client_subnet_disabled
+    new_record = Record::TXT.new(
+      fqdn: 'test_new_records_have_edns_client_subnet_disabled.test.recordstore.io',
+      ttl: 3600,
+      txtdata: 'Some answer'
+    )
+
+    json_request_body_matcher = lambda do |request_1, request_2|
+      return true if request_1.headers['Content-Type'] != ['application/json'] &&
+        request_2.headers['Content-Type'] != ['application/json']
+
+      request_1.uri == request_2.uri &&
+        request_1.method == request_2.method &&
+        JSON.parse(request_1.body) == JSON.parse(request_2.body)
+    end
+
+    # Cassette request body will assert that `use_client_subnet` is set to false in the request
+    VCR.use_cassette('ns1_test_new_records_have_edns_client_subnet_disabled', match_requests_on: [json_request_body_matcher]) do
+      @ns1.apply_changeset(Changeset.new(
+        current_records: [],
+        desired_records: [new_record],
+        provider: @ns1,
+        zone: @zone_name
+      ))
+    end
+  end
 end

--- a/test/providers/ns1_test.rb
+++ b/test/providers/ns1_test.rb
@@ -646,7 +646,10 @@ class NS1Test < Minitest::Test
     end
 
     # Cassette request body will assert that `use_client_subnet` is set to false in the request
-    VCR.use_cassette('ns1_test_new_records_have_edns_client_subnet_disabled', match_requests_on: [json_request_body_matcher]) do
+    VCR.use_cassette(
+      'ns1_test_new_records_have_edns_client_subnet_disabled',
+      match_requests_on: [json_request_body_matcher]
+    ) do
       @ns1.apply_changeset(Changeset.new(
         current_records: [],
         desired_records: [new_record],


### PR DESCRIPTION
record_store doesn't support filter chains in NS1 & thus does not require ECS extensions when creating new records for this provider.