### PR TITLE
Require all zones to be valid before applying any changesets

### DIFF
--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -103,8 +103,13 @@ module RecordStore
         exit
       end
 
-      if (invalid_zone = zones.find(&:invalid?))
-        abort("Attempted to apply invalid zone: #{invalid_zone.name}: #{invalid_zone.errors.full_messages.join(',')}")
+      invalid_zones = zones.select(&:invalid?)
+      unless invalid_zones.empty?
+        error_message = invalid_zones
+          .map { |z| "Attempted to apply invalid zone: #{z.name}: #{z.errors.full_messages.join(',')}" }
+          .join("\n")
+
+        abort(error_message)
       end
 
       zones.each do |zone|

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -103,9 +103,11 @@ module RecordStore
         exit
       end
 
-      zones.each do |zone|
-        abort("Attempted to apply invalid zone: #{zone.name}: #{zone.errors.full_messages.join(',')}") unless zone.valid?
+      if (invalid_zone = zones.find(&:invalid?))
+        abort("Attempted to apply invalid zone: #{invalid_zone.name}: #{invalid_zone.errors.full_messages.join(',')}")
+      end
 
+      zones.each do |zone|
         changesets = zone.build_changesets
         changesets.each(&:apply)
       end

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -104,7 +104,7 @@ module RecordStore
       end
 
       zones.each do |zone|
-        abort("Attempted to apply invalid zone: #{zone.name}") unless zone.valid?
+        abort("Attempted to apply invalid zone: #{zone.name}: #{zone.errors.full_messages.join(',')}") unless zone.valid?
 
         changesets = zone.build_changesets
         changesets.each(&:apply)

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.7.4'.freeze
+  VERSION = '5.8.0'.freeze
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -41,9 +41,9 @@ class CLITest < Minitest::Test
         ttl: 3600,
         txtdata: 'This record is valid',
       }]),
-      Zone.new(name: 'test2.recordstore.io', config: ns1_config, records: [{
+      Zone.new(name: 'sshfp1.test.recordstore.io', config: ns1_config, records: [{
         type: 'SSHFP',
-        fqdn: "ns1.does.not.support.sshfp.test2.recordstore.io.",
+        fqdn: "ns1.does.not.support.sshfp1.test.recordstore.io.",
         ttl: 3600,
         algorithm: Record::SSHFP::Algorithms::ED25519,
         fptype: Record::SSHFP::FingerprintTypes::SHA_256,

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -32,6 +32,34 @@ class CLITest < Minitest::Test
     ENV['EJSON_KEYDIR'] = ejson_keydir
   end
 
+  def test_applies_no_changes_if_any_zone_invalid
+    ns1_config = { providers: ['NS1'] }
+    Zone.expects(:modified).returns([
+      Zone.new(name: 'test.recordstore.io', config: ns1_config, records: [{
+        type: 'TXT',
+        fqdn: "test.recordstore.io.",
+        ttl: 3600,
+        txtdata: 'This record is valid',
+      }]),
+      Zone.new(name: 'test2.recordstore.io', config: ns1_config, records: [{
+        type: 'SSHFP',
+        fqdn: "ns1.does.not.support.sshfp.test2.recordstore.io.",
+        ttl: 3600,
+        algorithm: Record::SSHFP::Algorithms::ED25519,
+        fptype: Record::SSHFP::FingerprintTypes::SHA_256,
+        fingerprint: '0000000000000000000000000000000000000000000000000000000000000000',
+      }]),
+  ])
+
+  RecordStore::Changeset.any_instance.expects(:apply).never
+
+  VCR.use_cassette('test_applies_no_changes_if_any_zone_invalid') do
+      RecordStore::CLI.start(%w(apply))
+    end
+  rescue SystemExit
+    # pass: CLI is expected to `abort`. Prevent the Minitest reporter from dying.
+  end
+
   def test_returns_nonzero_exit_status
     stderr = STDERR.clone
     STDERR.reopen(File::NULL, "w")

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -49,11 +49,11 @@ class CLITest < Minitest::Test
         fptype: Record::SSHFP::FingerprintTypes::SHA_256,
         fingerprint: '0000000000000000000000000000000000000000000000000000000000000000',
       }]),
-  ])
+    ])
 
-  RecordStore::Changeset.any_instance.expects(:apply).never
+    RecordStore::Changeset.any_instance.expects(:apply).never
 
-  VCR.use_cassette('test_applies_no_changes_if_any_zone_invalid') do
+    VCR.use_cassette('test_applies_no_changes_if_any_zone_invalid') do
       RecordStore::CLI.start(%w(apply))
     end
   rescue SystemExit

--- a/test/fixtures/vcr_cassettes/test_does_not_allow_removal_of_sshfp_records.yml
+++ b/test/fixtures/vcr_cassettes/test_does_not_allow_removal_of_sshfp_records.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io/_sshfp1.test.recordstore.io/SSHFP
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 31 Mar 2020 22:30:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d80aeee7050aae13186c84d3fe8f917f21585693847; expires=Thu, 30-Apr-20
+        22:30:47 GMT; path=/; domain=.nsone.net; HttpOnly; SameSite=Lax
+      Cf-Ray:
+      - 57cd84519c45aba6-YYZ
+      Cache-Control:
+      - no-cache
+      Expires:
+      - '0'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Pragma:
+      - no-cache
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '900'
+      X-Ratelimit-Period:
+      - '300'
+      X-Ratelimit-Remaining:
+      - '899'
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+    body:
+      encoding: UTF-8
+      string: '{"message":"\"SSHFP\" not a manageable record type"}
+
+        '
+    http_version: null
+  recorded_at: Tue, 31 Mar 2020 22:30:47 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
Spun off from #155. Do not apply any Changesets if even a single Zone is invalid.

This prevents a set of Zones from being only partially applied, which leaves records at our DNS providers in an inconsistent state.