### PR TITLE
improved CLI support for debugging delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
+## 5.9.0
+- add `--all` option for `record-store list` to list ignored records too [FEATURE]
+- add `record-store info` command to list providers and delegation for zones [FEATURE]
+
+## 5.8.0
+- support SSHFP record type [FEATURE]
+
 ## 5.7.4
-- NS1: changing the way long TXT records are processed (no more splitting to do on our side)
+- NS1: changing the way long TXT records are processed (no more splitting to do on our side) [BUGFIX]
 
 ## 5.7.1
 - add API rate limit for NS1 provider [FEATURE]

--- a/lib/record_store.rb
+++ b/lib/record_store.rb
@@ -61,6 +61,7 @@ module RecordStore
     def config_path=(config_path)
       @config = @zones_path = @secrets_path = nil
       @config_path = config_path
+      Zone.reset
     end
 
     def config

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -33,10 +33,12 @@ module RecordStore
     end
 
     desc 'list', 'Lists out records in YAML zonefiles'
+    option :all, desc: 'Show all records', aliases: '-a', type: :boolean, default: false
     def list
       Zone.each do |name, zone|
         puts "Zone: #{name}"
-        zone.records.each(&:log!)
+        records = options.fetch('all') ? zone.all : zone.records
+        records.each(&:log!)
       end
     end
 

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -40,7 +40,7 @@ module RecordStore
         puts "Zone: #{name}"
         puts "Providers:"
         zone.config.providers.each { |p| puts "- #{p}" }
-        if delegation = zone.fetch_delegation
+        if (delegation = zone.fetch_delegation)
           puts "Delegation:"
           delegation.each { |d| puts "- #{d}" }
         else

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -32,6 +32,23 @@ module RecordStore
       end
     end
 
+    desc 'info', 'Show information about zones under management'
+    option :delegation, desc: 'Include delegation', aliases: '-d', type: :boolean, default: false
+    def info
+      Zone.each do |name, zone|
+        puts "\n"
+        puts "Zone: #{name}"
+        puts "Providers:"
+        zone.config.providers.each { |p| puts "- #{p}" }
+        if delegation = zone.fetch_delegation
+          puts "Delegation:"
+          delegation.each { |d| puts "- #{d}" }
+        else
+          STDERR.puts "ERROR: Unable to determine delegation (#{name})"
+        end
+      end
+    end
+
     desc 'list', 'Lists out records in YAML zonefiles'
     option :all, desc: 'Show all records', aliases: '-a', type: :boolean, default: false
     def list

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -40,8 +40,8 @@ module RecordStore
         puts "Zone: #{name}"
         puts "Providers:"
         zone.config.providers.each { |p| puts "- #{p}" }
-        if (delegation = zone.fetch_delegation)
-          puts "Delegation:"
+        if (delegation = zone.fetch_authority)
+          puts "Authoritative nameservers:"
           delegation.each { |d| puts "- #{d}" }
         else
           STDERR.puts "ERROR: Unable to determine delegation (#{name})"

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.8.0'.freeze
+  VERSION = '5.9.0'.freeze
 end

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -131,15 +131,13 @@ module RecordStore
     def fetch_delegation(nameserver = ROOT_SERVERS.sample)
       Resolv::DNS.open(nameserver: nameserver) do |resolv|
         resolv.fetch_resource(name, Resolv::DNS::Resource::IN::SOA) do |reply, name|
-          return if reply.answer.any?
+          break if reply.answer.any?
 
           raise "No authority found (#{name})" unless reply.authority.any?
 
-          return extract_delegation(reply)
+          break extract_delegation(reply)
         end
       end
-
-      nil
     end
 
     private

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -86,6 +86,10 @@ module RecordStore
       @name.chomp('.')
     end
 
+    def all
+      @records
+    end
+
     def records
       @records_cache ||= Zone.filter_records(@records, config.ignore_patterns)
     end

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -112,7 +112,53 @@ module RecordStore
       self.class.write(name, config: config, records: records, **write_options)
     end
 
+    ROOT_SERVERS = %w(
+      a.root-servers.net
+      b.root-servers.net
+      c.root-servers.net
+      d.root-servers.net
+      e.root-servers.net
+      f.root-servers.net
+      g.root-servers.net
+      h.root-servers.net
+      i.root-servers.net
+      j.root-servers.net
+      k.root-servers.net
+      l.root-servers.net
+      m.root-servers.net
+    )
+
+    def fetch_delegation(nameserver = ROOT_SERVERS.sample)
+      Resolv::DNS.open(nameserver: nameserver) do |resolv|
+        resolv.fetch_resource(name, Resolv::DNS::Resource::IN::SOA) do |reply, name|
+          return if reply.answer.any?
+
+          raise "No authority found (#{name})" unless reply.authority.any?
+
+          return extract_delegation(reply)
+        end
+      end
+
+      nil
+    end
+
     private
+
+    def extract_delegation(reply)
+      authority = reply.authority.sample
+
+      if unrooted_name.casecmp?(authority.first.to_s)
+        extract_authority(reply.authority)
+      else
+        fetch_delegation(authority.last.name.to_s) || extract_authority(reply.authority)
+      end
+    end
+
+    def extract_authority(authority)
+      authority.map.with_index do |(name, ttl, data), index|
+        Record::NS.new(ttl: ttl, fqdn: name.to_s, nsdname: data.name.to_s, record_id: index)
+      end
+    end
 
     def build_records(records)
       records.map { |record| Record.build_from_yaml_definition(record) }

--- a/test/cli/info_test.rb
+++ b/test/cli/info_test.rb
@@ -2,6 +2,18 @@ require 'test_helper'
 
 module CLI
   class InfoTest < Minitest::Test
+    def setup
+      super
+      Zone.expects(:defined).returns(
+        'example.com' => Zone.new(name: 'example.com', config: { providers: %w(DNSimple NS1) })
+      )
+    end
+
+    def teardown
+      super
+      RecordStore.config_path = DUMMY_CONFIG_PATH
+    end
+
     def test_prints_zone
       RecordStore::CLI.start(%w(info))
 
@@ -14,8 +26,7 @@ module CLI
       providers = <<~PROVIDERS
         Providers:
         - DNSimple
-        - DynECT
-        - GoogleCloudDNS
+        - NS1
       PROVIDERS
 
       assert_includes($stdout.string, providers)

--- a/test/cli/info_test.rb
+++ b/test/cli/info_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+module CLI
+  class InfoTest < Minitest::Test
+    def test_prints_zone
+      RecordStore::CLI.start(%w(info))
+
+      assert_includes($stdout.string, "Zone: example.com")
+    end
+
+    def test_lists_providers
+      RecordStore::CLI.start(%w(info))
+
+      providers = <<~PROVIDERS
+        Providers:
+        - DNSimple
+        - DynECT
+        - GoogleCloudDNS
+      PROVIDERS
+
+      assert_includes($stdout.string, providers)
+    end
+
+    def test_lists_authoritative_nameservers
+      RecordStore::CLI.start(%w(info))
+
+      authority = <<~AUTHORITY
+        Authoritative nameservers:
+        - [NSRecord] example.com. 172800 IN NS a.iana-servers.net.
+        - [NSRecord] example.com. 172800 IN NS b.iana-servers.net.
+      AUTHORITY
+
+      assert_includes($stdout.string, authority)
+    end
+  end
+end

--- a/test/fixtures/config/dummy/zones/ignored-ns.com.yml
+++ b/test/fixtures/config/dummy/zones/ignored-ns.com.yml
@@ -1,0 +1,30 @@
+ignored-ns.com:
+  config:
+    providers:
+    - DNSimple
+    ignore_patterns:
+    - type: NS
+      fqdn: ignored-ns.com.
+
+  records:
+    - type: A
+      fqdn: a-record.ignored-ns.com.
+      address: 10.10.10.10
+      ttl: 86400
+
+    - type: NS
+      fqdn: ignored-ns.com.
+      ttl: 3600
+      nsdname: ns1.dnsimple.com.
+    - type: NS
+      fqdn: ignored-ns.com.
+      ttl: 3600
+      nsdname: ns2.dnsimple.com.
+    - type: NS
+      fqdn: ignored-ns.com.
+      ttl: 3600
+      nsdname: ns3.dnsimple.com.
+    - type: NS
+      fqdn: ignored-ns.com.
+      ttl: 3600
+      nsdname: ns4.dnsimple.com.

--- a/test/support/test_config.rb
+++ b/test/support/test_config.rb
@@ -1,4 +1,6 @@
 module TestConfig
+  private
+
   def build_record_store_config(
     zones_path: 'zones/',
     secrets_path: 'secrets.json',

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -34,6 +34,12 @@ class ZoneTest < Minitest::Test
     assert_nil(Zone.find('missing-zone.com'))
   end
 
+  def test_zone_all_includes_ignored_records
+    zone = Zone.find('ignored-ns.com')
+    assert_equal(1, zone.records.size)
+    assert_equal(5, zone.all.size)
+  end
+
   def test_zone_has_configurable_ignore_pattern
     zone = Zone.find('one-record.com')
     assert_equal(1, zone.records.size)


### PR DESCRIPTION
This PR makes a couple of small changes to the `record-store` CLI to aid in debugging delegation issues.

1. adds an `--all` option to `record-store list` which will report ignored records as well.

2. adds a `record-store info` command to list the Providers and *actual* delegation for managed zones.

An example of `record-store info` output for one zone...
```
...
Zone: shopify.engineering
Providers:
- DNSimple
- NS1
Delegation:
- [NSRecord] shopify.engineering. 86400 IN NS dns3.p06.nsone.net.
- [NSRecord] shopify.engineering. 86400 IN NS dns4.p06.nsone.net.
- [NSRecord] shopify.engineering. 86400 IN NS ns4.dnsimple.com.
- [NSRecord] shopify.engineering. 86400 IN NS dns1.p06.nsone.net.
- [NSRecord] shopify.engineering. 86400 IN NS dns2.p06.nsone.net.
- [NSRecord] shopify.engineering. 86400 IN NS ns3.dnsimple.com.
- [NSRecord] shopify.engineering. 86400 IN NS ns1.dnsimple.com.
- [NSRecord] shopify.engineering. 86400 IN NS ns2.dnsimple.com.
...
```
