### PR TITLE
Capture output in tests

### DIFF
--- a/lib/record_store/record/spf.rb
+++ b/lib/record_store/record/spf.rb
@@ -1,7 +1,7 @@
 module RecordStore
   class Record::SPF < Record::TXT
     def initialize(record)
-      STDERR.puts "SPF record type is deprecated (See RFC 7208 Section 14.1)"
+      $stderr.puts "SPF record type is deprecated (See RFC 7208 Section 14.1)"
       super
     end
   end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -62,11 +62,7 @@ class CLITest < Minitest::Test
   end
 
   def test_returns_nonzero_exit_status
-    stderr = STDERR.clone
-    STDERR.reopen(File::NULL, "w")
     Thor.expects(:exit).with(false)
     RecordStore::CLI.start(%w(does not exist))
-  ensure
-    STDERR.reopen(stderr)
   end
 end

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -360,4 +360,9 @@ class RecordTest < Minitest::Test
       fingerprint: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
     ), :valid?)
   end
+
+  def test_spf_is_deprecated
+    Record::SPF.new(fqdn: 'dns-test.shopify.io.', txtdata: 'v=spf1 -all', ttl: 3600)
+    assert_includes($stderr.string, "SPF record type is deprecated (See RFC 7208 Section 14.1)")
+  end
 end

--- a/test/support/capture_output.rb
+++ b/test/support/capture_output.rb
@@ -1,0 +1,20 @@
+module CaptureOutput
+  def setup
+    super
+
+    @original_stdout = $stdout
+    @original_stderr = $stderr
+
+    $stdout = @captured_stdout = StringIO.new
+    $stderr = @captured_stderr = StringIO.new
+  end
+
+  def teardown
+    $stderr = @original_stderr
+    $stdout = @original_stdout
+
+    super
+  end
+end
+
+Minitest::Test.send(:prepend, CaptureOutput)

--- a/test/support/capture_output.rb
+++ b/test/support/capture_output.rb
@@ -17,4 +17,4 @@ module CaptureOutput
   end
 end
 
-Minitest::Test.send(:prepend, CaptureOutput)
+Minitest::Test.prepend(CaptureOutput)

--- a/test/support/provider_teardown.rb
+++ b/test/support/provider_teardown.rb
@@ -8,4 +8,4 @@ module ProviderTeardown
   end
 end
 
-Minitest::Test.send(:prepend, ProviderTeardown)
+Minitest::Test.prepend(ProviderTeardown)

--- a/test/support/test_config.rb
+++ b/test/support/test_config.rb
@@ -12,4 +12,4 @@ module TestConfig
   end
 end
 
-Minitest::Test.send(:prepend, TestConfig)
+Minitest::Test.prepend(TestConfig)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require 'record_store'
 
 DUMMY_CONFIG_PATH = File.expand_path('fixtures/config/dummy/config.yml', __dir__)
 RecordStore.config_path = DUMMY_CONFIG_PATH
-Minitest::Test.send(:include, RecordStore)
+Minitest::Test.include(RecordStore)
 
 Dir[File.expand_path('support/*', __dir__)].each do |path|
   require path


### PR DESCRIPTION
instead of letting things spew to the terminal during test runs, this PR captures stdout and stderr

it sets the stage to do better integration testing, and also removes a one-off case where a test closes STDOUT

oh... and it adds a test for a deprecation message for SPF records (by using the new capture capability)