### PR TITLE
fix gemspec to allow pushes to rubygems

### DIFF
--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -14,6 +14,12 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'https://github.com/Shopify/record_store'
   spec.license     = 'MIT'
 
+  if spec.respond_to?(:metadata)
+    spec.metadata['allowed_push_host'] = "https://rubygems.org"
+  else
+    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
+  end
+
   spec.files       = %x(git ls-files -z).split("\x0").reject { |f| f.match(/^(test|DESIGN)/) }
   spec.executables = ['record-store']
   spec.require_paths = ['lib']


### PR DESCRIPTION
shipit was updated to require explicit metadata to allow pushes to rubygems (in order to prevent accidentally pushing private gems)