### PR TITLE
bugfix for missing authoritative nameservers

### DIFF
--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -44,7 +44,7 @@ module RecordStore
           puts "Authoritative nameservers:"
           delegation.each { |d| puts "- #{d}" }
         else
-          STDERR.puts "ERROR: Unable to determine delegation (#{name})"
+          $stderr.puts "ERROR: Unable to determine delegation (#{name})"
         end
       end
     end

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -129,7 +129,7 @@ module RecordStore
     )
 
     def fetch_authority(nameserver = ROOT_SERVERS.sample)
-      Resolv::DNS.open(nameserver: nameserver) do |resolv|
+      authority = Resolv::DNS.open(nameserver: nameserver) do |resolv|
         resolv.fetch_resource(name, Resolv::DNS::Resource::IN::SOA) do |reply, name|
           break if reply.answer.any?
 
@@ -138,6 +138,11 @@ module RecordStore
           break extract_authority(reply)
         end
       end
+
+      # candidate DNS name is returned instead when NXDomain or other error
+      return nil if unrooted_name.casecmp?(Array(authority).first.to_s)
+
+      authority
     end
 
     private

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -464,6 +464,18 @@ class ZoneTest < Minitest::Test
     assert_equal(expected, nameservers)
   end
 
+  def test_fetch_authority_handles_nxdomain
+    zone = Zone.new(name: 'bc1a82e63eede5c2962efb11df850eea7d4c9a2a-nxdomain.com')
+    nameservers = zone.fetch_authority
+    assert_equal(nameservers.first.fqdn, 'com.')
+  end
+
+  def test_fetch_authority_handles_nxdomain_for_tld
+    zone = Zone.new(name: 'nxdomain.bc1a82e63eede5c2962efb11df850eea7d4c9a2a')
+    nameservers = zone.fetch_authority
+    assert_nil(nameservers)
+  end
+
   private
 
   def valid_zone_from_records(name, records:)

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -454,6 +454,16 @@ class ZoneTest < Minitest::Test
     end
   end
 
+  def test_fetch_authority
+    zone = Zone.new(name: 'example.com')
+    nameservers = zone.fetch_authority
+    expected = [
+      Record::NS.new(fqdn: 'example.com', ttl: 172_800, nsdname: 'a.iana-servers.net.'),
+      Record::NS.new(fqdn: 'example.com', ttl: 172_800, nsdname: 'b.iana-servers.net.'),
+    ]
+    assert_equal(expected, nameservers)
+  end
+
   private
 
   def valid_zone_from_records(name, records:)


### PR DESCRIPTION
this PR adds unit tests for authoritative nameserver lookup, and fixes the case where a domain is not delegated
