### PR TITLE
add command to validate authoritative DNS for providers

### DIFF
--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -223,7 +223,7 @@ module RecordStore
       Zone.each do |name, zone|
         authority = zone.fetch_authority
 
-        delegation = Hash.new { |h,k| h[k] = [] }
+        delegation = Hash.new { |h, k| h[k] = [] }
         authority.each do |ns|
           delegation[Provider.provider_for(ns)] << ns
         end

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -24,7 +24,9 @@ module RecordStore
           'DynECT'
         when /\.googledomains\.com\z/
           'GoogleCloudDNS'
-        when /\.nsone\.net\z/
+        when /\.nsone\.net\z/,
+             /\.ns1global\.net\z/,
+             /\.ns1global\.org\z/
           'NS1'
         when /\.oraclecloud\.net\z/
           'OracleCloudDNS'

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -3,13 +3,19 @@ require 'resolv'
 module RecordStore
   class Provider
     class << self
-      def provider_for(zone_name)
-        begin
-          ns_server = master_nameserver_for(zone_name)
-        rescue Resolv::ResolvError
-          $stderr.puts "Domain doesn't exist (#{zone_name})"
-          return
-        end
+      def provider_for(object)
+        ns_server =
+          case object
+          when Record::NS
+            object.nsdname.chomp('.')
+          else
+            begin
+              master_nameserver_for(object)
+            rescue Resolv::ResolvError
+              $stderr.puts "Domain doesn't exist (#{object})"
+              return
+            end
+          end
 
         case ns_server
         when /\.dnsimple\.com\z/

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -4,12 +4,11 @@ module RecordStore
   class Provider
     class << self
       def provider_for(zone_name)
-        dns = Resolv::DNS.new(nameserver: ['8.8.8.8', '8.8.4.4'])
-
         begin
-          ns_server = dns.getresource(zone_name, Resolv::DNS::Resource::IN::SOA).mname.to_s
+          ns_server = master_nameserver_for(zone_name)
         rescue Resolv::ResolvError
-          abort("Domain doesn't exist")
+          $stderr.puts "Domain doesn't exist (#{zone_name})"
+          return
         end
 
         case ns_server
@@ -114,6 +113,12 @@ module RecordStore
 
       def update(id, record)
         raise NotImplementedError
+      end
+
+      def master_nameserver_for(zone_name)
+        dns = Resolv::DNS.new(nameserver: ['8.8.8.8', '8.8.4.4'])
+
+        dns.getresource(zone_name, Resolv::DNS::Resource::IN::SOA).mname.to_s
       end
     end
   end

--- a/test/cli/validate_authority_test.rb
+++ b/test/cli/validate_authority_test.rb
@@ -1,0 +1,151 @@
+require 'test_helper'
+
+module CLI
+  class ValidateAuthorityTest < Minitest::Test
+    def teardown
+      super
+      RecordStore.config_path = DUMMY_CONFIG_PATH
+    end
+
+    def test_prints_zones
+      mock_zone('business.new', authority: ns_unknown('new'))
+
+      RecordStore::CLI.start(%w(validate_authority))
+
+      assert_includes($stdout.string, "Zone: business.new")
+    end
+
+    def test_excludes_valid_zone
+      mock_zone('shopify.com')
+
+      RecordStore::CLI.start(%w(validate_authority))
+
+      refute_includes($stdout.string, "Zone: shopify.com")
+    end
+
+    def test_verbose_option_includes_valid_zones
+      mock_zone('shopify.com')
+
+      RecordStore::CLI.start(%w(validate_authority --verbose))
+
+      assert_includes($stdout.string, "Zone: shopify.com")
+    end
+
+    def test_reports_missing_authority
+      mock_zone('myshopify.cloud', authority: ns_dnsimple('myshopify.cloud'))
+      RecordStore::CLI.start(%w(validate_authority))
+
+      assert_includes($stdout.string, "- NS1: authoritative nameservers not found for configured provider")
+    end
+
+    def test_excludes_valid_authority
+      mock_zone('myshopify.cloud', authority: ns_dnsimple('myshopify.cloud'))
+      RecordStore::CLI.start(%w(validate_authority))
+
+      refute_includes($stdout.string, "- DNSimple:")
+    end
+
+    def test_verbose_option_includes_valid_authority
+      mock_zone('myshopify.cloud', authority: ns_dnsimple('myshopify.cloud'))
+      RecordStore::CLI.start(%w(validate_authority --verbose))
+
+      authority = <<~AUTHORITY
+        - DNSimple:
+          - ns1.dnsimple.com.
+          - ns2.dnsimple.com.
+          - ns3.dnsimple.com.
+          - ns4.dnsimple.com.
+      AUTHORITY
+
+      assert_includes($stdout.string, authority)
+    end
+
+    def test_reports_extra_authority
+      mock_zone('myshopify.cloud', providers: %w(DNSimple))
+      RecordStore::CLI.start(%w(validate_authority))
+
+      authority = <<~AUTHORITY
+        - NS1: unexpected authoritative nameservers found
+          - ns1.p06.nsone.net.
+          - ns2.p06.nsone.net.
+          - ns3.p06.nsone.net.
+          - ns4.p06.nsone.net.
+      AUTHORITY
+
+      assert_includes($stdout.string, authority)
+    end
+
+    def test_reports_unknown_authority
+      mock_zone('business.new', authority: ns_unknown('new'))
+
+      RecordStore::CLI.start(%w(validate_authority))
+
+      assert_includes($stdout.string, "Zone: business.new")
+
+      authority = <<~AUTHORITY
+        - Unknown: unknown authoritative nameservers found
+          - ns1.charlestonroadregistry.com.
+          - ns2.charlestonroadregistry.com.
+          - ns3.charlestonroadregistry.com.
+          - ns4.charlestonroadregistry.com.
+          - ns5.charlestonroadregistry.com.
+      AUTHORITY
+
+      assert_includes($stdout.string, authority)
+    end
+
+    private
+
+    def mock_zone(zone_name, providers: %w(DNSimple NS1), authority: ns_dnsimple(zone_name) + ns_ns1(zone_name))
+      zone = Zone.new(name: zone_name, config: { providers: providers })
+      zone.expects(:fetch_authority).returns(authority)
+      Zone.expects(:defined).returns(zone_name => zone)
+    end
+
+    def ns_records(fqdn:, nsdomain:, count:, ttl: 172800)
+      count.times.map do |i|
+        Record::NS.new(fqdn: fqdn, ttl: ttl, nsdname: "ns#{i + 1}.#{nsdomain}.")
+      end
+    end
+
+    def ns_dnsimple(fqdn)
+      ns_records(fqdn: fqdn, nsdomain: 'dnsimple.com', count: 4)
+    end
+
+    def ns_googlecloud(fqdn)
+      ns_records(fqnd: fqdn, nsdomain: 'googledomains.com', count: 4)
+    end
+
+    def ns_ns1(fqdn)
+      ns_records(fqdn: fqdn, nsdomain: 'p06.nsone.net', count: 4)
+    end
+
+    def ns_unknown(fqdn)
+      ns_records(fqdn: fqdn, nsdomain: 'charlestonroadregistry.com', count: 5)
+    end
+
+    # def test_lists_providers
+    #   RecordStore::CLI.start(%w(info))
+
+    #   providers = <<~PROVIDERS
+    #     Providers:
+    #     - DNSimple
+    #     - NS1
+    #   PROVIDERS
+
+    #   assert_includes($stdout.string, providers)
+    # end
+
+    # def test_lists_authoritative_nameservers
+    #   RecordStore::CLI.start(%w(info))
+
+    #   authority = <<~AUTHORITY
+    #     Authoritative nameservers:
+    #     - [NSRecord] example.com. 172800 IN NS a.iana-servers.net.
+    #     - [NSRecord] example.com. 172800 IN NS b.iana-servers.net.
+    #   AUTHORITY
+
+    #   assert_includes($stdout.string, authority)
+    # end
+  end
+end

--- a/test/provider_test.rb
+++ b/test/provider_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class ProviderTest < Minitest::Test
+  def test_provider_for_recognizes_dnsimple_soa_for_zone_name
+    Provider.expects(:master_nameserver_for).with('dnsimple.com').returns('ns1.dnsimple.com')
+    provider = Provider.provider_for('dnsimple.com')
+    assert_equal('DNSimple', provider)
+  end
+
+  def test_provider_for_recognizes_dynect_soa_for_zone_name
+    Provider.expects(:master_nameserver_for).with('dynect.net').returns('ns1.p19.dynect.net')
+    provider = Provider.provider_for('dynect.net')
+    assert_equal('DynECT', provider)
+  end
+
+  def test_provider_for_recognizes_google_cloud_dns_soa_for_zone_name
+    Provider.expects(:master_nameserver_for).with('googledomains.com').returns('ns5.googledomains.com')
+    provider = Provider.provider_for('googledomains.com')
+    assert_equal('GoogleCloudDNS', provider)
+  end
+
+  def test_provider_for_recognizes_nsone_soa_for_zone_name
+    Provider.expects(:master_nameserver_for).with('nsone.net').returns('dns1.p01.nsone.net')
+    provider = Provider.provider_for('nsone.net')
+    assert_equal('NS1', provider)
+  end
+
+  def test_provider_for_recognizes_oraclecloud_soa_for_zone_name
+    Provider.expects(:master_nameserver_for).with('oraclecloud.net').returns('ns1.p68.dns.oraclecloud.net')
+    provider = Provider.provider_for('oraclecloud.net')
+    assert_equal('OracleCloudDNS', provider)
+  end
+
+  def test_provider_for_recognizes_dnsimple_soa_for_zone_name
+    Provider.expects(:master_nameserver_for).with('dnsimple.com').returns('ns1.dnsimple.com')
+    provider = Provider.provider_for('dnsimple.com')
+    assert_equal('DNSimple', provider)
+  end
+
+  def test_provider_for_handles_unknown_provider
+    Provider.expects(:master_nameserver_for).with('example.com').returns('ns.icann.org')
+    provider = Provider.provider_for('example.com')
+    assert_nil(provider)
+  end
+
+  def test_provider_for_handles_unknown_domain
+    Provider.expects(:master_nameserver_for).with('unknown-domain.com').raises(Resolv::ResolvError)
+    provider = Provider.provider_for('unknown-domain.com')
+    assert_nil(provider)
+  end
+end

--- a/test/provider_test.rb
+++ b/test/provider_test.rb
@@ -55,6 +55,18 @@ class ProviderTest < Minitest::Test
     assert_equal('NS1', provider)
   end
 
+  def test_provider_for_recognizes_nsone_global_org_ns_record
+    ns = Record::NS.new(fqdn: 'nsone.net', ttl: 172_800, nsdname: 'dns1.g01.ns1global.org.')
+    provider = Provider.provider_for(ns)
+    assert_equal('NS1', provider)
+  end
+
+  def test_provider_for_recognizes_nsone_global_net_ns_record
+    ns = Record::NS.new(fqdn: 'nsone.net', ttl: 172_800, nsdname: 'dns1.g01.ns1global.net.')
+    provider = Provider.provider_for(ns)
+    assert_equal('NS1', provider)
+  end
+
   def test_provider_for_recognizes_oraclecloud_ns_record
     ns = Record::NS.new(fqdn: 'oraclecloud.net', ttl: 172_800, nsdname: 'ns1.p68.dns.oraclecloud.net.')
     provider = Provider.provider_for(ns)

--- a/test/provider_test.rb
+++ b/test/provider_test.rb
@@ -61,12 +61,6 @@ class ProviderTest < Minitest::Test
     assert_equal('OracleCloudDNS', provider)
   end
 
-  def test_provider_for_recognizes_dnsimple_ns_record
-    ns = Record::NS.new(fqdn: 'dnsimple.com', ttl: 172_800, nsdname: 'ns1.dnsimple.com.')
-    provider = Provider.provider_for(ns)
-    assert_equal('DNSimple', provider)
-  end
-
   def test_provider_for_handles_unknown_provider
     Provider.expects(:master_nameserver_for).with('example.com').returns('ns.icann.org')
     provider = Provider.provider_for('example.com')

--- a/test/provider_test.rb
+++ b/test/provider_test.rb
@@ -37,6 +37,42 @@ class ProviderTest < Minitest::Test
     assert_equal('DNSimple', provider)
   end
 
+  def test_provider_for_recognizes_dnsimple_ns_record
+    ns = Record::NS.new(fqdn: 'dnsimple.com', ttl: 172_800, nsdname: 'ns1.dnsimple.com.')
+    provider = Provider.provider_for(ns)
+    assert_equal('DNSimple', provider)
+  end
+
+  def test_provider_for_recognizes_dynect_ns_record
+    ns = Record::NS.new(fqdn: 'dynect.net', ttl: 172_800, nsdname: 'ns1.p19.dynect.net.')
+    provider = Provider.provider_for(ns)
+    assert_equal('DynECT', provider)
+  end
+
+  def test_provider_for_recognizes_google_cloud_dns_ns_record
+    ns = Record::NS.new(fqdn: 'googledomains.com', ttl: 172_800, nsdname: 'ns5.googledomains.com.')
+    provider = Provider.provider_for(ns)
+    assert_equal('GoogleCloudDNS', provider)
+  end
+
+  def test_provider_for_recognizes_nsone_ns_record
+    ns = Record::NS.new(fqdn: 'nsone.net', ttl: 172_800, nsdname: 'dns1.p01.nsone.net.')
+    provider = Provider.provider_for(ns)
+    assert_equal('NS1', provider)
+  end
+
+  def test_provider_for_recognizes_oraclecloud_ns_record
+    ns = Record::NS.new(fqdn: 'oraclecloud.net', ttl: 172_800, nsdname: 'ns1.p68.dns.oraclecloud.net.')
+    provider = Provider.provider_for(ns)
+    assert_equal('OracleCloudDNS', provider)
+  end
+
+  def test_provider_for_recognizes_dnsimple_ns_record
+    ns = Record::NS.new(fqdn: 'dnsimple.com', ttl: 172_800, nsdname: 'ns1.dnsimple.com.')
+    provider = Provider.provider_for(ns)
+    assert_equal('DNSimple', provider)
+  end
+
   def test_provider_for_handles_unknown_provider
     Provider.expects(:master_nameserver_for).with('example.com').returns('ns.icann.org')
     provider = Provider.provider_for('example.com')

--- a/test/provider_test.rb
+++ b/test/provider_test.rb
@@ -31,12 +31,6 @@ class ProviderTest < Minitest::Test
     assert_equal('OracleCloudDNS', provider)
   end
 
-  def test_provider_for_recognizes_dnsimple_soa_for_zone_name
-    Provider.expects(:master_nameserver_for).with('dnsimple.com').returns('ns1.dnsimple.com')
-    provider = Provider.provider_for('dnsimple.com')
-    assert_equal('DNSimple', provider)
-  end
-
   def test_provider_for_recognizes_dnsimple_ns_record
     ns = Record::NS.new(fqdn: 'dnsimple.com', ttl: 172_800, nsdname: 'ns1.dnsimple.com.')
     provider = Provider.provider_for(ns)


### PR DESCRIPTION
this PR adds a `validate_authority` command to verify provider delegation to authoritative nameservers

```
Usage:
  record-store validate_authority

Options:
  -v, [--verbose], [--no-verbose]  # Include valid zones in output
  -c, [--config=CONFIG]            # Path to config.yml

Validates that authoritative nameservers match the providers
```

example output...
```
bin/record-store validate_authority

Zone: splunkctf.io
- NS1: authoritative nameservers not found for configured provider

Zone: shopifyplus.ar
- DNSimple: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - a.dns.ar.
  - b.dns.ar.
  - c.dns.ar.
  - d.dns.ar.
  - e.dns.ar.
  - f.dns.ar.
  - ar.cctld.authdns.ripe.net.

Zone: buyable-pin.com
- NS1: authoritative nameservers not found for configured provider

Zone: business.new
- DNSimple: authoritative nameservers not found for configured provider
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns-tld1.charlestonroadregistry.com.
  - ns-tld2.charlestonroadregistry.com.
  - ns-tld3.charlestonroadregistry.com.
  - ns-tld4.charlestonroadregistry.com.
  - ns-tld5.charlestonroadregistry.com.

Zone: beyondthecode.io
- NS1: authoritative nameservers not found for configured provider

Zone: tookanl.com
- DNSimple: authoritative nameservers not found for configured provider
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - dns1.registrar-servers.com.
  - dns2.registrar-servers.com.

Zone: shopify.cn
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - dns4.g01.ns1global.org.
  - dns1.g01.ns1global.org.
  - dns2.g01.ns1global.org.
  - dns3.g01.ns1global.org.

Zone: frenzy.fail
- DNSimple: authoritative nameservers not found for configured provider
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - dns1.registrar-servers.com.
  - dns2.registrar-servers.com.

Zone: sto.re
- DNSimple: authoritative nameservers not found for configured provider
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns1162.ispapi.net.
  - ns3167.ispapi.net.
  - ns2163.ispapi.net.

Zone: myshopify.cloud
- NS1: authoritative nameservers not found for configured provider

Zone: shopifyplus.com.kz
- DNSimple: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns2.hoster.kz.
  - ns3.hoster.kz.
  - ns1.hoster.kz.

Zone: shopifyplus.ee
- DNSimple: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns.tld.ee.
  - ee.aso.ee.
  - e.tld.ee.
  - b.tld.ee.
  - ee.eenet.ee.

Zone: activemerchant.org
- NS1: authoritative nameservers not found for configured provider

Zone: shopifyplus.kz
- DNSimple: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns1.hoster.kz.
  - ns3.hoster.kz.
  - ns2.hoster.kz.

Zone: oberlo.com.br
- NS1: authoritative nameservers not found for configured provider

Zone: ecommerce-calendar.com
- DNSimple: authoritative nameservers not found for configured provider
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns1.markmonitor.com.
  - ns3.markmonitor.com.
  - ns4.markmonitor.com.
  - ns2.markmonitor.com.

Zone: buyable-pins.com
- NS1: authoritative nameservers not found for configured provider

Zone: test.recordstore.chrome
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns-tld1.charlestonroadregistry.com.
  - ns-tld2.charlestonroadregistry.com.
  - ns-tld3.charlestonroadregistry.com.
  - ns-tld4.charlestonroadregistry.com.
  - ns-tld5.charlestonroadregistry.com.

Zone: shopify.com.cn
- DNSimple: authoritative nameservers not found for configured provider

Zone: shopify.com.co
- NS1: authoritative nameservers not found for configured provider

Zone: storecontest.com
- NS1: authoritative nameservers not found for configured provider

Zone: buyablepins.com
- NS1: authoritative nameservers not found for configured provider

Zone: buyablepin.com
- NS1: authoritative nameservers not found for configured provider

Zone: joinpopup.com
- DNSimple: authoritative nameservers not found for configured provider
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns33.domaincontrol.com.
  - ns34.domaincontrol.com.

Zone: leetsoft.com
- DNSimple: authoritative nameservers not found for configured provider
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns1.hover.com.
  - ns2.hover.com.

Zone: snowdevil.ca
- NS1: authoritative nameservers not found for configured provider

Zone: shopifyplus.co.th
- DNSimple: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns01.trademarkarea.com.
  - ns02.trademarkarea.com.
  - ns03.trademarkarea.com.

Zone: shopifyplus.ba
- DNSimple: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns01.trademarkarea.com.
  - ns02.trademarkarea.com.
  - ns03.trademarkarea.com.

Zone: shopifyplus.co.za
- DNSimple: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns.coza.net.za.
  - ns3.iafrica.com.
  - coza1.dnsnode.net.
  - ns2us.dns.business.
  - ns0.is.co.za.

Zone: shopifyplus.mk
- DNSimple: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns01.trademarkarea.com.
  - ns02.trademarkarea.com.
  - ns03.trademarkarea.com.

Zone: ecommerce-university.com
- DNSimple: authoritative nameservers not found for configured provider
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns1.markmonitor.com.
  - ns3.markmonitor.com.
  - ns4.markmonitor.com.
  - ns2.markmonitor.com.

Zone: burstmode.com
- NS1: authoritative nameservers not found for configured provider

Zone: plt.co
- DNSimple: authoritative nameservers not found for configured provider
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns4.easily.net.
  - ns3.easily.net.

Zone: shopify-ns1.com
- NS1: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - dns1.g01.ns1global.org.
  - dns2.g01.ns1global.org.
  - dns3.g01.ns1global.org.
  - dns4.g01.ns1global.org.

Zone: shopifyplus.com.ar
- DNSimple: authoritative nameservers not found for configured provider
- Unknown: unknown authoritative nameservers found
  - ns2.sedoparking.com.
  - ns1.sedoparking.com.

Zone: showussomethingcool.com
- NS1: authoritative nameservers not found for configured provider

Zone: buildwithshopify.com
- NS1: authoritative nameservers not found for configured provider
```