### PR TITLE
bump to version 5.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # CHANGELOG
+
+## 5.10.0
+- add `record-store validate_authority` command to sanity check delegation [FEATURE]
+- fix handling of NXDOMAIN, etc. when fetching authoritative nameservers [BUGFIX]
+
 ## 5.9.0
 - add `--all` option for `record-store list` to list ignored records too [FEATURE]
 - add `record-store info` command to list providers and delegation for zones [FEATURE]

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.9.0'.freeze
+  VERSION = '5.10.0'.freeze
 end


### PR DESCRIPTION
## 5.10.0
- add `record-store validate_authority` command to sanity check delegation [FEATURE]
- fix handling of NXDOMAIN, etc. when fetching authoritative nameservers [BUGFIX]
