### PR TITLE
add option to include ignored records in diff

### DIFF
--- a/lib/record_store/changeset.rb
+++ b/lib/record_store/changeset.rb
@@ -36,12 +36,15 @@ module RecordStore
 
     attr_reader :current_records, :desired_records, :removals, :additions, :updates, :provider, :zone
 
-    def self.build_from(provider:, zone:)
+    def self.build_from(provider:, zone:, all: false)
       current_zone = provider.build_zone(zone_name: zone.unrooted_name, config: zone.config)
 
+      current_records = all ? current_zone.all : current_zone.records
+      desired_records = all ? zone.all : zone.records
+
       new(
-        current_records: current_zone.records,
-        desired_records: zone.records,
+        current_records: current_records,
+        desired_records: desired_records,
         provider: provider,
         zone: zone.unrooted_name
       )

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -60,12 +60,15 @@ module RecordStore
     end
 
     desc 'diff', 'Displays the DNS differences between the zone files in this repo and production'
+    option :all, desc: 'Include all records', aliases: '-a', type: :boolean, default: false
     option :verbose, desc: 'Print records that haven\'t diverged', aliases: '-v', type: :boolean, default: false
     def diff
       puts "Diffing #{Zone.defined.count} zones"
 
+      all = options.fetch('all')
+
       Zone.each do |name, zone|
-        changesets = zone.build_changesets
+        changesets = zone.build_changesets(all: all)
 
         if !options.fetch('verbose') && changesets.all?(&:empty?)
           print_and_flush('.')

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -70,10 +70,10 @@ module RecordStore
       @records = build_records(records)
     end
 
-    def build_changesets
+    def build_changesets(all: false)
       @changesets ||= begin
         providers.map do |provider|
-          Changeset.build_from(provider: provider, zone: self)
+          Changeset.build_from(provider: provider, zone: self, all: all)
         end
       end
     end

--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'fog-xml'
   spec.add_runtime_dependency 'fog-dynect', '~> 0.4.0'
   spec.add_runtime_dependency 'dnsimple', '~> 4.4.0'
-  spec.add_runtime_dependency 'google-cloud-dns'
+  spec.add_runtime_dependency 'google-cloud-dns', '~> 0.31.0'
   spec.add_runtime_dependency 'ruby-limiter', '~> 1.0', '>= 1.0.1'
   spec.add_runtime_dependency 'ns1'
   spec.add_runtime_dependency 'oci', '~> 2.6.0'

--- a/test/changeset_test.rb
+++ b/test/changeset_test.rb
@@ -189,7 +189,7 @@ class ChangesetTest < Minitest::Test
       name: 'dns-test.shopify.io',
       config: {
         providers: ['DynECT'],
-        ignore_patterns: [{ type: 'NS', fqdn: 'dns-test.shopify.io.'}],
+        ignore_patterns: [{ type: 'NS', fqdn: 'dns-test.shopify.io.' }],
       },
       records: [{
         type: 'NS',
@@ -234,7 +234,7 @@ class ChangesetTest < Minitest::Test
       name: 'dns-test.shopify.io',
       config: {
         providers: ['DynECT'],
-        ignore_patterns: [{ type: 'NS', fqdn: 'dns-test.shopify.io.'}],
+        ignore_patterns: [{ type: 'NS', fqdn: 'dns-test.shopify.io.' }],
       },
       records: [{
         type: 'NS',

--- a/test/changeset_test.rb
+++ b/test/changeset_test.rb
@@ -184,6 +184,97 @@ class ChangesetTest < Minitest::Test
     end
   end
 
+  def test_changeset_build_from_creates_changeset_excluding_ignored_records
+    zone = Zone.new(
+      name: 'dns-test.shopify.io',
+      config: {
+        providers: ['DynECT'],
+        ignore_patterns: [{ type: 'NS', fqdn: 'dns-test.shopify.io.'}],
+      },
+      records: [{
+        type: 'NS',
+        ttl: 86400,
+        fqdn: 'dns-test.shopify.io',
+        nsdname: 'ns1.p19.dynect.net.',
+      }, {
+        type: 'NS',
+        ttl: 86400,
+        fqdn: 'dns-test.shopify.io',
+        nsdname: 'ns2.p19.dynect.net.',
+      }, {
+        type: 'NS',
+        ttl: 86400,
+        fqdn: 'dns-test.shopify.io',
+        nsdname: 'ns3.p19.dynect.net.',
+      }, {
+        type: 'A',
+        ttl: 86400,
+        fqdn: 'test-record.dns-test.shopify.io',
+        address: '10.10.10.10',
+      }, {
+        type: 'ALIAS',
+        ttl: 60,
+        fqdn: 'dns-test.shopify.io',
+        alias: 'dns-test.herokuapp.com.',
+      }]
+    )
+
+    # Cassette matches zone's records except with an additional NS record
+    VCR.use_cassette('dynect_retrieve_current_records') do
+      changeset = Changeset.build_from(provider: zone.providers[0], zone: zone)
+
+      assert_predicate changeset.removals, :empty?
+      assert_predicate changeset.additions, :empty?
+      refute_predicate changeset.unchanged, :empty?
+    end
+  end
+
+  def test_changeset_build_from_creates_changeset_including_ignored_records
+    zone = Zone.new(
+      name: 'dns-test.shopify.io',
+      config: {
+        providers: ['DynECT'],
+        ignore_patterns: [{ type: 'NS', fqdn: 'dns-test.shopify.io.'}],
+      },
+      records: [{
+        type: 'NS',
+        ttl: 86400,
+        fqdn: 'dns-test.shopify.io',
+        nsdname: 'ns1.p19.dynect.net.',
+      }, {
+        type: 'NS',
+        ttl: 86400,
+        fqdn: 'dns-test.shopify.io',
+        nsdname: 'ns2.p19.dynect.net.',
+      }, {
+        type: 'NS',
+        ttl: 86400,
+        fqdn: 'dns-test.shopify.io',
+        nsdname: 'ns3.p19.dynect.net.',
+      }, {
+        type: 'A',
+        ttl: 86400,
+        fqdn: 'test-record.dns-test.shopify.io',
+        address: '10.10.10.10',
+      }, {
+        type: 'ALIAS',
+        ttl: 60,
+        fqdn: 'dns-test.shopify.io',
+        alias: 'dns-test.herokuapp.com.',
+      }]
+    )
+
+    # Cassette matches zone's records except with an additional NS record
+    VCR.use_cassette('dynect_retrieve_current_records') do
+      changeset = Changeset.build_from(provider: zone.providers[0], zone: zone, all: true)
+
+      assert_equal 1, changeset.removals.length
+      assert_kind_of Record::NS, changeset.removals[0].record
+      assert_predicate changeset.additions, :empty?
+      refute_predicate changeset.unchanged, :empty?
+    end
+  end
+
   def test_records_with_matching_content_take_priority_when_being_updated
     current_records = [
       Record::NS.new(

--- a/test/fixtures/vcr_cassettes/gcloud_dns_apply_changeset.yml
+++ b/test/fixtures/vcr_cassettes/gcloud_dns_apply_changeset.yml
@@ -57,7 +57,7 @@ http_interactions:
   recorded_at: Fri, 19 Jan 2018 23:00:56 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/dns/v1/projects/project_id/managedZones/dns-test-shopify-io
+    uri: https://dns.googleapis.com/dns/v1/projects/project_id/managedZones/dns-test-shopify-io
     body:
       encoding: UTF-8
       string: ''
@@ -132,7 +132,7 @@ http_interactions:
   recorded_at: Fri, 19 Jan 2018 23:00:56 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/dns/v1/projects/project_id/managedZones/4643813348782290994/rrsets?name=dns-test.shopify.io.&type=SOA
+    uri: https://dns.googleapis.com/dns/v1/projects/project_id/managedZones/4643813348782290994/rrsets?name=dns-test.shopify.io.&type=SOA
     body:
       encoding: UTF-8
       string: ''
@@ -207,7 +207,7 @@ http_interactions:
   recorded_at: Fri, 19 Jan 2018 23:00:56 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/dns/v1/projects/project_id/managedZones/4643813348782290994/changes
+    uri: https://dns.googleapis.com/dns/v1/projects/project_id/managedZones/4643813348782290994/changes
     body:
       encoding: UTF-8
       string: '{"additions":[{"kind":"dns#resourceRecordSet","name":"test-record.dns-test.shopify.io.","rrdatas":["10.10.10.42"],"ttl":86400,"type":"A"},{"kind":"dns#resourceRecordSet","name":"dns-test.shopify.io.","rrdatas":["ns-cloud-b1.googledomains.com.

--- a/test/fixtures/vcr_cassettes/gcloud_dns_retrieve_current_records.yml
+++ b/test/fixtures/vcr_cassettes/gcloud_dns_retrieve_current_records.yml
@@ -57,7 +57,7 @@ http_interactions:
   recorded_at: Mon, 08 Jan 2018 23:26:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/dns/v1/projects/project_id/managedZones/dns-scratch-me
+    uri: https://dns.googleapis.com/dns/v1/projects/project_id/managedZones/dns-scratch-me
     body:
       encoding: UTF-8
       string: ''
@@ -132,7 +132,7 @@ http_interactions:
   recorded_at: Mon, 08 Jan 2018 23:26:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/dns/v1/projects/project_id/managedZones/759513122143970307/rrsets
+    uri: https://dns.googleapis.com/dns/v1/projects/project_id/managedZones/759513122143970307/rrsets
     body:
       encoding: UTF-8
       string: ''

--- a/test/fixtures/vcr_cassettes/gcloud_dns_zones.yml
+++ b/test/fixtures/vcr_cassettes/gcloud_dns_zones.yml
@@ -57,7 +57,7 @@ http_interactions:
   recorded_at: Mon, 08 Jan 2018 23:26:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/dns/v1/projects/project_id/managedZones
+    uri: https://dns.googleapis.com/dns/v1/projects/project_id/managedZones
     body:
       encoding: UTF-8
       string: ''


### PR DESCRIPTION
similar to the addition of a `--all` option for the `list` command to include ignored records,
this PR adds support for `--all` to the `diff` command as well, to show differences between the ignored records in the zone definition, and the actual records in the provider(s)

it also makes it possible to specify which zones to diff (rather than all defined ones)

sample output...
```
$ bin/record-store diff --all kafka.shopifysvc.com
Diffing 1 zone(s)

Zone: kafka.shopifysvc.com
--------------------
Provider: DNSimple
Add:
 - [NSRecord] kafka.shopifysvc.com. 3600 IN NS dns1.p07.nsone.net.
 - [NSRecord] kafka.shopifysvc.com. 3600 IN NS dns2.p07.nsone.net.
 - [NSRecord] kafka.shopifysvc.com. 3600 IN NS dns3.p07.nsone.net.
 - [NSRecord] kafka.shopifysvc.com. 3600 IN NS dns4.p07.nsone.net.
====================
```
