### PR TITLE
bump version to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.0.0
+- add `--all` option for `record-store diff` to compare ignored records too [FEATURE]
+
 ## 5.11.0
 - support PTR record type [FEATURE]
 

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '5.11.0'.freeze
+  VERSION = '6.0.0'.freeze
 end


### PR DESCRIPTION
bump gem version to make `record-store diff --all` available

(bumping major version to 6 because of gem dependency bump)
