### PR TITLE
Add rate limiting for DNSimple provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # CHANGELOG
+## 6.0.1
+- add API rate limiting to DNSimple provider
 
 ## 6.0.0
 - add `--all` option for `record-store diff` to compare ignored records too [FEATURE]

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -1,4 +1,5 @@
 require 'dnsimple'
+require_relative 'dnsimple/patch_api_header'
 
 module RecordStore
   class Provider::DNSimple < Provider

--- a/lib/record_store/provider/dnsimple/patch_api_header.rb
+++ b/lib/record_store/provider/dnsimple/patch_api_header.rb
@@ -1,0 +1,30 @@
+# Patch Dnsimple client method which retrieves headers for API rate limit dynamically
+module Dnsimple
+  class Client
+    def execute(method, path, data = nil, options = {})
+      response = request(method, path, data, options)
+      rate_limit_sleep(response.headers["x-ratelimit-reset"].to_i, response.headers["x-ratelimit-remaining"].to_i)
+
+      case response.code
+      when 200..299
+        response
+      when 401
+        raise AuthenticationFailed, response["message"]
+      when 404
+        raise NotFoundError, response
+      else
+        raise RequestError, response
+      end
+    end
+
+    private
+
+    def rate_limit_sleep(rate_limit_reset, rate_limit_remaining)
+      rate_limit_reset_in = [0, rate_limit_reset - Time.now.to_i].max
+      rate_limit_periods = rate_limit_remaining + 1
+      wait_time = rate_limit_reset_in / rate_limit_periods.to_f
+
+      sleep(wait_time) if wait_time > 0
+    end
+  end
+end

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.0.0'.freeze
+  VERSION = '6.0.1'.freeze
 end


### PR DESCRIPTION
Patches the DNSimple client to add API rate limiting. This follows a similar approach to how it was done for the [NS1 provider](https://github.com/Shopify/record_store/blob/master/lib/record_store/provider/ns1/patch_api_header.rb#L6-L8).