### PR TITLE
handle non-NS records returned as authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - sort zone files [FEATURE]
 - CLI support for specifying zones for validate_authority [FEATURE]
 - retry failed lookup using another nameserver if unreachable [BUGFIX]
+- ignore records other than NS in authority section [BUGFIX]
 
 ## 6.0.1
 - add API rate limiting to DNSimple provider [FEATURE]

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -175,7 +175,9 @@ module RecordStore
     end
 
     def build_authority(authority)
-      authority.map.with_index do |(name, ttl, data), index|
+      ns = authority.select { |_name, _ttl, data| data.is_a?(Resolv::DNS::Resource::IN::NS) }
+
+      ns.map.with_index do |(name, ttl, data), index|
         Record::NS.new(ttl: ttl, fqdn: name.to_s, nsdname: data.name.to_s, record_id: index)
       end
     end


### PR DESCRIPTION
The original implementation assumed all records in the authority section were all NS records, but other record types can be present. This PR updates to filter out non-NS records.
