### PR TITLE
Handle unreachable host when looking up authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 - sort zone files [FEATURE]
 - CLI support for specifying zones for validate_authority [FEATURE]
+- retry failed lookup using another nameserver if unreachable [BUGFIX]
 
 ## 6.0.1
 - add API rate limiting to DNSimple provider [FEATURE]

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -145,9 +145,11 @@ module RecordStore
 
     private
 
-    def fetch_soa(nameserver, &block)
+    def fetch_soa(nameserver)
       Resolv::DNS.open(nameserver: nameserver) do |resolv|
-        resolv.fetch_resource(name, Resolv::DNS::Resource::IN::SOA, &block)
+        resolv.fetch_resource(name, Resolv::DNS::Resource::IN::SOA) do |reply, name|
+          yield reply, name
+        end
       end
     end
 

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -129,14 +129,12 @@ module RecordStore
     )
 
     def fetch_authority(nameserver = ROOT_SERVERS.sample)
-      authority = Resolv::DNS.open(nameserver: nameserver) do |resolv|
-        resolv.fetch_resource(name, Resolv::DNS::Resource::IN::SOA) do |reply, name|
-          break if reply.answer.any?
+      authority = fetch_soa(nameserver) do |reply, _name|
+        break if reply.answer.any?
 
-          raise "No authority found (#{name})" unless reply.authority.any?
+        raise "No authority found (#{name})" unless reply.authority.any?
 
-          break extract_authority(reply.authority)
-        end
+        break extract_authority(reply.authority)
       end
 
       # candidate DNS name is returned instead when NXDomain or other error
@@ -146,6 +144,12 @@ module RecordStore
     end
 
     private
+
+    def fetch_soa(nameserver, &block)
+      Resolv::DNS.open(nameserver: nameserver) do |resolv|
+        resolv.fetch_resource(name, Resolv::DNS::Resource::IN::SOA, &block)
+      end
+    end
 
     def resolve_authority(authority)
       nameservers = authority.map { |a| a.last.name.to_s }

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -545,7 +545,9 @@ class ZoneTest < Minitest::Test
   private
 
   def mock_name(name)
-    mock('name')
+    n = mock('name')
+    n.stubs(:to_s).returns(name)
+    n
   end
 
   def mock_ns(name)

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -500,7 +500,6 @@ class ZoneTest < Minitest::Test
 
     zone.expects(:fetch_soa).with('b.root-servers.net')
       .yields(mock_reply('ph.', ['ph.communitydns.net', '1.ns.ph']), mock_name('shopify.ph.'))
-      .returns([mock('result')])
 
     zone.expects(:fetch_soa).with('ph.communitydns.net')
       .raises(Errno::EHOSTUNREACH)


### PR DESCRIPTION
this PR implements retry if an authoritative NS is unreachable

#### update: test added