### PR TITLE
Add print when waiting for rate-limit to elapse so deployment doesn't timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.1.1
+- Emit messages when waiting for rate-limit to elapse for DNSimple and NS1 providers, so deployment does not timeout [BUGFIX]
+
 ## 6.1.0
 - sort zone files [FEATURE]
 - CLI support for specifying zones for validate_authority [FEATURE]

--- a/lib/record_store/provider/dnsimple/patch_api_header.rb
+++ b/lib/record_store/provider/dnsimple/patch_api_header.rb
@@ -1,15 +1,17 @@
+require_relative '../provider_utils/rate_limit'
+
 # Patch Dnsimple client method which retrieves headers for API rate limit dynamically
 module Dnsimple
   class Client
     def execute(method, path, data = nil, options = {})
       response = request(method, path, data, options)
-      rate_limit_sleep(response.headers["x-ratelimit-reset"].to_i, response.headers["x-ratelimit-remaining"].to_i)
+      rate_limit_sleep(response.headers['x-ratelimit-reset'].to_i, response.headers['x-ratelimit-remaining'].to_i)
 
       case response.code
       when 200..299
         response
       when 401
-        raise AuthenticationFailed, response["message"]
+        raise AuthenticationFailed, response['message']
       when 404
         raise NotFoundError, response
       else
@@ -22,9 +24,10 @@ module Dnsimple
     def rate_limit_sleep(rate_limit_reset, rate_limit_remaining)
       rate_limit_reset_in = [0, rate_limit_reset - Time.now.to_i].max
       rate_limit_periods = rate_limit_remaining + 1
-      wait_time = rate_limit_reset_in / rate_limit_periods.to_f
+      sleep_time = rate_limit_reset_in / rate_limit_periods.to_f
 
-      sleep(wait_time) if wait_time > 0
+      rate_limit = RateLimit.new('DNSimple')
+      rate_limit.sleep_for(sleep_time)
     end
   end
 end

--- a/lib/record_store/provider/ns1/patch_api_header.rb
+++ b/lib/record_store/provider/ns1/patch_api_header.rb
@@ -1,11 +1,15 @@
 require 'net/http'
+require_relative '../provider_utils/rate_limit'
 
 # Patch the method which retrieves headers for API rate limit dynamically
 module NS1::Transport
   class NetHttp
     def process_response(response)
-      sleep(response.to_hash["x-ratelimit-period"].first.to_i /
-        [1, response.to_hash["x-ratelimit-remaining"].first.to_i].max.to_f)
+      sleep_time = response.to_hash['x-ratelimit-period'].first.to_i /
+                   [1, response.to_hash['x-ratelimit-remaining'].first.to_i].max.to_f
+
+      rate_limit = RateLimit.new('NS1')
+      rate_limit.sleep_for(sleep_time)
 
       body = JSON.parse(response.body)
       case response

--- a/lib/record_store/provider/provider_utils/rate_limit.rb
+++ b/lib/record_store/provider/provider_utils/rate_limit.rb
@@ -1,0 +1,14 @@
+class RateLimit
+  def initialize(provider)
+    @provider = provider
+  end
+
+  def sleep_for(sleep_time)
+    while sleep_time > 0
+      wait = [10, sleep_time].min
+      puts "Waiting on #{@provider} rate-limit" if wait > 1
+      sleep(wait)
+      sleep_time -= wait
+    end
+  end
+end

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.1.0'.freeze
+  VERSION = '6.1.1'.freeze
 end

--- a/test/providers/dnsimple_test.rb
+++ b/test/providers/dnsimple_test.rb
@@ -520,7 +520,7 @@ class DNSimpleTest < Minitest::Test
 
     Time.stubs(:now).returns(current_time_to_test)
     session = @dnsimple.send(:session)
-    session.expects(:sleep).never
+    RateLimit.any_instance.expects(:sleep).never
     session.send(:rate_limit_sleep, rate_limit_reset, rate_limit_remaining)
   end
 
@@ -536,7 +536,8 @@ class DNSimpleTest < Minitest::Test
   def helper_rate_limit_sleep_test(current_time, rate_limit_reset, rate_limit_remaining, expected_sleep_duration)
     session = @dnsimple.send(:session)
     Time.stubs(:now).returns(current_time)
-    session.expects(:sleep).with(expected_sleep_duration)
+    RateLimit.any_instance.stubs(:sleep_for)
+    RateLimit.any_instance.expects(:sleep_for).with(expected_sleep_duration)
     session.send(:rate_limit_sleep, rate_limit_reset, rate_limit_remaining)
   end
 end

--- a/test/providers/provider_utils/rate_limit_test.rb
+++ b/test/providers/provider_utils/rate_limit_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class RateLimitTest < Minitest::Test
+  def setup
+    super
+    @rate_limit = RateLimit.new('Test_Provider')
+  end
+
+  def test_sleep_for_negative_time
+    sleep_time = -1 * rand(10)
+    @rate_limit.expects(:sleep).never
+    @rate_limit.sleep_for(sleep_time)
+  end
+
+  def test_sleep_for_long_time
+    # If sleep_for is called with time gearter than 10
+    sleep_time = rand(11..100)
+    time_divided_by_ten = (sleep_time / 10)
+    sleep_calls = (sleep_time % 10).zero? ? time_divided_by_ten : time_divided_by_ten + 1
+    expect_sleep_called(sleep_time, sleep_calls)
+  end
+
+  def test_sleep_for_short_time
+    # If sleep_for is called with time less 10
+    sleep_time = rand(1..11)
+    expect_sleep_called(sleep_time, 1)
+  end
+
+  def expect_sleep_called(sleep_time, sleep_calls)
+    @rate_limit.stubs(:sleep)
+    @rate_limit.expects(:sleep).times(sleep_calls)
+    @rate_limit.sleep_for(sleep_time)
+  end
+end


### PR DESCRIPTION
This PR is to prevent Shipit from timing out because of a lack of output when waiting for the NS1 rate-limit to elapse. To do this we emit a "waiting" message `Waiting on NS1 provider` every 10 seconds to let Shipit know that we're still alive and just waiting for our rate-limit to elapse.