### PR TITLE
Retry read operations on connection errors

### DIFF
--- a/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -671,7 +671,7 @@ Style/LineEndConcatenation:
 Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
-Style/MethodMissingSuper:
+Lint/MissingSuper:
   Enabled: true
 
 Style/MissingRespondToMissing:
@@ -964,7 +964,7 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   Enabled: true
 
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
 Lint/UselessElseWithoutRescue:

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -142,9 +142,13 @@ module RecordStore
           rescue Net::OpenTimeout
             raise if max_timeouts <= 0
             max_timeouts -= 1
+
+            $stderr.puts("Retrying after a connection timeout")
           rescue Errno::ECONNRESET
             raise if max_conn_resets <= 0
             max_conn_resets -= 1
+
+            $stderr.puts("Retrying in #{delay}s after a connection reset")
             backoff_sleep(delay)
             delay = [delay * backoff_multiplier, max_backoff].min
           end

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -128,6 +128,20 @@ module RecordStore
 
         dns.getresource(zone_name, Resolv::DNS::Resource::IN::SOA).mname.to_s
       end
+
+      def retry_on_connection_errors(max_timeouts: 5, max_conn_resets: 5)
+        loop do
+          begin
+            return yield
+          rescue Net::OpenTimeout
+            raise if max_timeouts <= 0
+            max_timeouts -= 1
+          rescue Errno::ECONNRESET
+            raise if max_conn_resets <= 0
+            max_conn_resets -= 1
+          end
+        end
+      end
     end
   end
 end

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -14,19 +14,23 @@ module RecordStore
 
       # returns an array of Record objects that match the records which exist in the provider
       def retrieve_current_records(zone:, stdout: $stdout)
-        session.zones.all_records(account_id, zone).data.map do |record|
-          begin
-            build_from_api(record, zone)
-          rescue StandardError
-            stdout.puts "Cannot build record: #{record}"
-            raise
-          end
-        end.compact
+        retry_on_connection_errors do
+          session.zones.all_records(account_id, zone).data.map do |record|
+            begin
+              build_from_api(record, zone)
+            rescue StandardError
+              stdout.puts "Cannot build record: #{record}"
+              raise
+            end
+          end.compact
+        end
       end
 
       # Returns an array of the zones managed by provider as strings
       def zones
-        session.zones.all_zones(account_id).data.map(&:name)
+        retry_on_connection_errors do
+          session.zones.all_zones(account_id).data.map(&:name)
+        end
       end
 
       private

--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -60,14 +60,18 @@ module RecordStore
 
       # Returns an array of the zones managed by provider as strings
       def zones
-        client.zones.map { |zone| zone['zone'] }
+        retry_on_connection_errors do
+          client.zones.map { |zone| zone['zone'] }
+        end
       end
 
       private
 
       # Fetches simplified records for the provided zone
       def records_for_zone(zone)
-        client.zone(zone)['records']
+        retry_on_connection_errors do
+          client.zone(zone)['records']
+        end
       end
 
       # Creates a new record to the zone. It is expected this call modifies external state.

--- a/lib/record_store/provider/ns1/patch_api_header.rb
+++ b/lib/record_store/provider/ns1/patch_api_header.rb
@@ -10,7 +10,7 @@ module NS1::Transport
     def process_response(response)
       response_hash = response.to_hash
 
-      if (response_hash.key?(X_RATELIMIT_PERIOD) && response_hash.key?(X_RATELIMIT_REMAINING))
+      if response_hash.key?(X_RATELIMIT_PERIOD) && response_hash.key?(X_RATELIMIT_REMAINING)
         sleep_time = response_hash[X_RATELIMIT_PERIOD].first.to_i /
                      [1, response_hash[X_RATELIMIT_REMAINING].first.to_i].max.to_f
 

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.1.1'.freeze
+  VERSION = '6.1.2'.freeze
 end

--- a/test/providers/dnsimple_connection_errors_test.rb
+++ b/test/providers/dnsimple_connection_errors_test.rb
@@ -7,9 +7,9 @@ class DNSimpleConnectionErrorsTest < Minitest::Test
       "current_page": 1,
       "per_page": 1,
       "total_entries": 0,
-      "total_pages": 1
+      "total_pages": 1,
     },
-    "data": []
+    "data": [],
   }.to_json.freeze
 
   def setup

--- a/test/providers/dnsimple_connection_errors_test.rb
+++ b/test/providers/dnsimple_connection_errors_test.rb
@@ -18,6 +18,8 @@ class DNSimpleConnectionErrorsTest < Minitest::Test
   end
 
   def test_retrieve_current_records_retries_on_network_errors
+    @dnsimple.expects(:backoff_sleep).times(5).returns(true)
+
     stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones/zone/records\?page=1&per_page=100})
       .to_timeout.times(5)
       .to_raise(Errno::ECONNRESET).times(5)
@@ -27,6 +29,8 @@ class DNSimpleConnectionErrorsTest < Minitest::Test
   end
 
   def test_retrieve_current_records_eventually_raises_after_too_many_timeouts
+    @dnsimple.expects(:backoff_sleep).never
+
     stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones/zone/records\?page=1&per_page=100})
       .to_timeout.times(6)
 
@@ -36,6 +40,8 @@ class DNSimpleConnectionErrorsTest < Minitest::Test
   end
 
   def test_retrieve_current_records_raises_after_too_many_conn_resets
+    @dnsimple.expects(:backoff_sleep).times(5).returns(true)
+
     stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones/zone/records\?page=1&per_page=100})
       .to_raise(Errno::ECONNRESET).times(6)
 
@@ -45,6 +51,8 @@ class DNSimpleConnectionErrorsTest < Minitest::Test
   end
 
   def test_zones_retries_on_network_errors
+    @dnsimple.expects(:backoff_sleep).times(5).returns(true)
+
     stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones\?page=1&per_page=100})
       .to_timeout.times(5)
       .to_raise(Errno::ECONNRESET).times(5)
@@ -54,6 +62,8 @@ class DNSimpleConnectionErrorsTest < Minitest::Test
   end
 
   def test_zones_eventually_raises_after_too_many_timeouts
+    @dnsimple.expects(:backoff_sleep).never
+
     stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones\?page=1&per_page=100})
       .to_timeout.times(6)
 
@@ -63,6 +73,8 @@ class DNSimpleConnectionErrorsTest < Minitest::Test
   end
 
   def test_zones_raises_after_too_many_conn_resets
+    @dnsimple.expects(:backoff_sleep).times(5).returns(true)
+
     stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones\?page=1&per_page=100})
       .to_raise(Errno::ECONNRESET).times(6)
 

--- a/test/providers/dnsimple_connection_errors_test.rb
+++ b/test/providers/dnsimple_connection_errors_test.rb
@@ -1,0 +1,73 @@
+require 'test_helper'
+require 'json'
+
+class DNSimpleConnectionErrorsTest < Minitest::Test
+  MOCK_RESPONSE = {
+    "pagination" => {
+      "current_page": 1,
+      "per_page": 1,
+      "total_entries": 0,
+      "total_pages": 1
+    },
+    "data": []
+  }.to_json.freeze
+
+  def setup
+    super
+    @dnsimple = Provider::DNSimple
+  end
+
+  def test_retrieve_current_records_retries_on_network_errors
+    stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones/zone/records\?page=1&per_page=100})
+      .to_timeout.times(5)
+      .to_raise(Errno::ECONNRESET).times(5)
+      .then.to_return(body: MOCK_RESPONSE)
+
+    @dnsimple.retrieve_current_records(zone: 'zone')
+  end
+
+  def test_retrieve_current_records_eventually_raises_after_too_many_timeouts
+    stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones/zone/records\?page=1&per_page=100})
+      .to_timeout.times(6)
+
+    assert_raises(Net::OpenTimeout) do
+      @dnsimple.retrieve_current_records(zone: 'zone')
+    end
+  end
+
+  def test_retrieve_current_records_raises_after_too_many_conn_resets
+    stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones/zone/records\?page=1&per_page=100})
+      .to_raise(Errno::ECONNRESET).times(6)
+
+    assert_raises(Errno::ECONNRESET) do
+      @dnsimple.retrieve_current_records(zone: 'zone')
+    end
+  end
+
+  def test_zones_retries_on_network_errors
+    stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones\?page=1&per_page=100})
+      .to_timeout.times(5)
+      .to_raise(Errno::ECONNRESET).times(5)
+      .then.to_return(body: MOCK_RESPONSE)
+
+    @dnsimple.zones
+  end
+
+  def test_zones_eventually_raises_after_too_many_timeouts
+    stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones\?page=1&per_page=100})
+      .to_timeout.times(6)
+
+    assert_raises(Net::OpenTimeout) do
+      @dnsimple.zones
+    end
+  end
+
+  def test_zones_raises_after_too_many_conn_resets
+    stub_request(:get, %r{https://api.sandbox.dnsimple.com/v2/.+?/zones\?page=1&per_page=100})
+      .to_raise(Errno::ECONNRESET).times(6)
+
+    assert_raises(Errno::ECONNRESET) do
+      @dnsimple.zones
+    end
+  end
+end

--- a/test/providers/ns1_connection_errors_test.rb
+++ b/test/providers/ns1_connection_errors_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class NS1ConnectionErrorsTest < Minitest::Test
+  def setup
+    super
+    @ns1 = Provider::NS1
+  end
+
+  def test_retrieve_current_records_retries_on_network_errors
+    stub_request(:get, "https://api.nsone.net/v1/zones/zone")
+      .to_timeout.times(5)
+      .to_raise(Errno::ECONNRESET).times(5)
+      .then.to_return(body: '{ "records": []}')
+
+    @ns1.retrieve_current_records(zone: 'zone')
+  end
+
+  def test_retrieve_current_records_eventually_raises_after_too_many_timeouts
+    stub_request(:get, "https://api.nsone.net/v1/zones/zone")
+      .to_timeout.times(6)
+
+    assert_raises(Net::OpenTimeout) do
+      @ns1.retrieve_current_records(zone: 'zone')
+    end
+  end
+
+  def test_retrieve_current_records_raises_after_too_many_conn_resets
+    stub_request(:get, "https://api.nsone.net/v1/zones/zone")
+      .to_raise(Errno::ECONNRESET).times(6)
+
+    assert_raises(Errno::ECONNRESET) do
+      @ns1.retrieve_current_records(zone: 'zone')
+    end
+  end
+
+  def test_zones_retries_on_network_errors
+    stub_request(:get, "https://api.nsone.net/v1/zones")
+      .to_timeout.times(5)
+      .to_raise(Errno::ECONNRESET).times(5)
+      .then.to_return(body: '[]')
+
+    @ns1.zones
+  end
+
+  def test_zones_raises_after_too_many_timeouts
+    stub_request(:get, "https://api.nsone.net/v1/zones")
+      .to_timeout.times(6)
+
+    assert_raises(Net::OpenTimeout) do
+      @ns1.zones
+    end
+  end
+
+  def test_zones_raises_after_too_many_conn_resets
+    stub_request(:get, "https://api.nsone.net/v1/zones")
+      .to_raise(Errno::ECONNRESET).times(6)
+
+    assert_raises(Errno::ECONNRESET) do
+      @ns1.zones
+    end
+  end
+end

--- a/test/providers/ns1_connection_errors_test.rb
+++ b/test/providers/ns1_connection_errors_test.rb
@@ -7,6 +7,8 @@ class NS1ConnectionErrorsTest < Minitest::Test
   end
 
   def test_retrieve_current_records_retries_on_network_errors
+    @ns1.expects(:backoff_sleep).times(5).returns(true)
+
     stub_request(:get, "https://api.nsone.net/v1/zones/zone")
       .to_timeout.times(5)
       .to_raise(Errno::ECONNRESET).times(5)
@@ -16,6 +18,8 @@ class NS1ConnectionErrorsTest < Minitest::Test
   end
 
   def test_retrieve_current_records_eventually_raises_after_too_many_timeouts
+    @ns1.expects(:backoff_sleep).never
+
     stub_request(:get, "https://api.nsone.net/v1/zones/zone")
       .to_timeout.times(6)
 
@@ -25,6 +29,8 @@ class NS1ConnectionErrorsTest < Minitest::Test
   end
 
   def test_retrieve_current_records_raises_after_too_many_conn_resets
+    @ns1.expects(:backoff_sleep).times(5).returns(true)
+
     stub_request(:get, "https://api.nsone.net/v1/zones/zone")
       .to_raise(Errno::ECONNRESET).times(6)
 
@@ -34,6 +40,8 @@ class NS1ConnectionErrorsTest < Minitest::Test
   end
 
   def test_zones_retries_on_network_errors
+    @ns1.expects(:backoff_sleep).times(5).returns(true)
+
     stub_request(:get, "https://api.nsone.net/v1/zones")
       .to_timeout.times(5)
       .to_raise(Errno::ECONNRESET).times(5)
@@ -43,6 +51,8 @@ class NS1ConnectionErrorsTest < Minitest::Test
   end
 
   def test_zones_raises_after_too_many_timeouts
+    @ns1.expects(:backoff_sleep).never
+
     stub_request(:get, "https://api.nsone.net/v1/zones")
       .to_timeout.times(6)
 
@@ -52,6 +62,8 @@ class NS1ConnectionErrorsTest < Minitest::Test
   end
 
   def test_zones_raises_after_too_many_conn_resets
+    @ns1.expects(:backoff_sleep).times(5).returns(true)
+
     stub_request(:get, "https://api.nsone.net/v1/zones")
       .to_raise(Errno::ECONNRESET).times(6)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'vcr'
 require 'pry'
 require 'fileutils'
 require 'webmock'
+require 'webmock/minitest'
 
 $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 require 'record_store'


### PR DESCRIPTION
**What's the problem?**

- `record_store` doesn't really protect its transactions.  A failure during during a CI run in which `record_store` is run could result in inconsistencies between a `record_store` configuration and DNS providers.
- For this reason, it's important that `record_store` does not fail unnecessarily.
- Transient network problems (connection timeouts, connection resets), although rare, could cause `record_store` to fail, but can be retried if they occur during read operations.

**How does this help?**

By performing a limited number of retries where a request hits connection timeouts or connection resets.  The threshold of errors is reached when 5 connection timeouts or 5 connection resets are encountered on a single connection attempt.  These counters could be expanded as new network issues emerge in provider APIs.

**Review tips?**

I wasn't able to figure out a way to perform tests directly using VCR, so I fell back to Webmock.  If it's possible to simulate a connection reset or timeout in VCR, please let me know.