### PR TITLE
Add support for raising errors when an empty non terminal overrides a wildcard

### DIFF
--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -52,6 +52,10 @@ module RecordStore
         false
       end
 
+      def empty_non_terminal_over_wildcard?
+        true
+      end
+
       def build_zone(zone_name:, config:)
         zone = Zone.new(name: zone_name)
         zone.records = retrieve_current_records(zone: zone_name)

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -12,6 +12,10 @@ module RecordStore
         true
       end
 
+      def empty_non_terminal_over_wildcard?
+        false
+      end
+
       # returns an array of Record objects that match the records which exist in the provider
       def retrieve_current_records(zone:, stdout: $stdout)
         retry_on_connection_errors do

--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -112,7 +112,7 @@ module RecordStore
       "[#{type}Record] #{fqdn} #{ttl} IN #{type} #{rdata_txt}"
     end
 
-    def is_wildcard?
+    def wildcard?
       fqdn.match?(/^\*\./)
     end
 

--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -112,6 +112,10 @@ module RecordStore
       "[#{type}Record] #{fqdn} #{ttl} IN #{type} #{rdata_txt}"
     end
 
+    def is_wildcard?
+      fqdn.match?(/^\*\./)
+    end
+
     protected
 
     def validate_label_length

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.1.2'.freeze
+  VERSION = '6.2.0'.freeze
 end

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -262,7 +262,7 @@ module RecordStore
     def validate_no_empty_non_terminal
       return unless config.empty_non_terminal_over_wildcard?
 
-      wildcards = records.select(&:is_wildcard?).map(&:fqdn).uniq
+      wildcards = records.select(&:wildcard?).map(&:fqdn).uniq
       wildcards.each do |wildcard|
         suffix = wildcard.delete_prefix('*')
 

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -264,7 +264,7 @@ module RecordStore
 
       wildcards = records.select(&:wildcard?).map(&:fqdn).uniq
       wildcards.each do |wildcard|
-        suffix = wildcard.delete_prefix('*')
+        suffix = wildcard[1..-1]
 
         terminal_records = records.map(&:fqdn)
           .select { |record| record.match?(/^([a-zA-Z0-9-_]+\.[a-zA-Z0-9-_])#{Regexp.escape(suffix)}$/) }

--- a/lib/record_store/zone/config.rb
+++ b/lib/record_store/zone/config.rb
@@ -24,6 +24,10 @@ module RecordStore
         end
       end
 
+      def empty_non_terminal_over_wildcard?
+        valid_providers? && providers.any? { |provider| Provider.const_get(provider).empty_non_terminal_over_wildcard? }
+      end
+
       def to_hash
         config_hash = {
           providers: providers,

--- a/test/zone/config_test.rb
+++ b/test/zone/config_test.rb
@@ -37,6 +37,7 @@ example.com:
       zone.config.ignore_patterns.map(&:to_hash))
     assert_equal(['DynECT', 'DNSimple'], zone.config.providers)
     assert_predicate(zone.config, :supports_alias?)
+    assert_predicate(zone.config, :empty_non_terminal_over_wildcard?)
   end
 
   def test_config_supports_alias_based_on_provider
@@ -50,5 +51,18 @@ example.com:
   def test_config_does_not_supports_alias_when_multiple_providers_disagree
     config = Zone.new(name: 'dnsimple-config.com', config: { providers: ['DNSimple', 'DynECT'] }).config
     refute_predicate(config, :supports_alias?)
+  end
+
+  def test_config_empty_non_terminal_over_wildcard_when_multiple_providers_disagree
+    config = Zone.new(name: 'dnsimple-config.com', config: { providers: ['DNSimple', 'DynECT'] }).config
+    assert_predicate(config, :empty_non_terminal_over_wildcard?)
+  end
+
+  def test_config_empty_non_terminal_over_wildcard_based_on_provider
+    config = Zone.new(name: 'dynect-config.com', config: { providers: ['DynECT'] }).config
+    assert_predicate(config, :empty_non_terminal_over_wildcard?)
+
+    config = Zone.new(name: 'dnsimple-config.com', config: { providers: ['DNSimple'] }).config
+    refute_predicate(config, :empty_non_terminal_over_wildcard?)
   end
 end


### PR DESCRIPTION
### What's the problem?

All providers do not behave the same way for non-empty terminal records over wildcards. For instance:
 - If you have record `*.domain.example.com` that `CNAME` to `target1.example.com`
 - If you create record `a.b.domain.example.com` that `CNAME` to `target2.example.com`
 - Some providers (case A) will consider that `b.domain.example.com` is a `CNAME` to `target1.example.com` (using the wildcard).
 - Some providers (case B) will consider that `b.domain.example.com` is an empty non-terminal, and will return `NODATA` (skipping the `CNAME`). In this case, having the `b.domain.example.com` record created is **mandatory** if you want it to resolve.

### How does this help?

We introduce a new `non_empty_terminal_over_wildcard` configuration parameter for the zone, that will be deduced automatically from the zone if _at least_ one provider used for the zone behaves like providers described in case B. If that parameter is `true`, a validation step will check that no empty non-terminal records are introduced in the configuration, leading to a failing validation unless the intermediate records is added.