### PR TITLE
Also retry when a timeout manifests as an Errno::ETIMEDOUT

### DIFF
--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -150,7 +150,7 @@ module RecordStore
         loop do
           begin
             return yield
-          rescue Net::OpenTimeout
+          rescue Net::OpenTimeout, Errno::ETIMEDOUT
             raise if max_timeouts <= 0
             max_timeouts -= 1
 

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.2.0'.freeze
+  VERSION = '6.2.1'.freeze
 end

--- a/test/providers/ns1_connection_errors_test.rb
+++ b/test/providers/ns1_connection_errors_test.rb
@@ -30,6 +30,18 @@ class NS1ConnectionErrorsTest < Minitest::Test
     end
   end
 
+  def test_retrieve_current_records_eventually_raises_after_too_many_low_level_timeouts
+    BackoffWaiter.any_instance.stubs(:wait)
+    BackoffWaiter.any_instance.expects(:wait).never
+
+    stub_request(:get, "https://api.nsone.net/v1/zones/zone")
+      .to_raise(Errno::ETIMEDOUT).times(6)
+
+    assert_raises(Errno::ETIMEDOUT) do
+      @ns1.retrieve_current_records(zone: 'zone')
+    end
+  end
+
   def test_retrieve_current_records_raises_after_too_many_conn_resets
     BackoffWaiter.any_instance.stubs(:wait)
     BackoffWaiter.any_instance.expects(:wait).times(5).returns(nil)
@@ -49,6 +61,17 @@ class NS1ConnectionErrorsTest < Minitest::Test
     stub_request(:get, "https://api.nsone.net/v1/zones")
       .to_timeout.times(5)
       .to_raise(Errno::ECONNRESET).times(5)
+      .then.to_return(body: '[]')
+
+    @ns1.zones
+  end
+
+  def test_zones_retries_on_low_level_timeouts
+    BackoffWaiter.any_instance.stubs(:wait)
+    BackoffWaiter.any_instance.expects(:wait).never
+
+    stub_request(:get, "https://api.nsone.net/v1/zones")
+      .to_raise(Errno::ETIMEDOUT).times(5)
       .then.to_return(body: '[]')
 
     @ns1.zones


### PR DESCRIPTION
**What's the problem?**

Remember #173 ?  It doesn't handle another type of timeout, Errno::ETIMEDOUT

**How does this fix it?**

Also retries on these errors.