### PR TITLE
escape hyphen in regex

### DIFF
--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -267,11 +267,11 @@ module RecordStore
         suffix = wildcard[1..-1]
 
         terminal_records = records.map(&:fqdn)
-          .select { |record| record.match?(/^([a-zA-Z0-9-_]+\.[a-zA-Z0-9-_])#{Regexp.escape(suffix)}$/) }
+          .select { |record| record.match?(/^([a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_])#{Regexp.escape(suffix)}$/) }
         next unless terminal_records.any?
 
         intermediate_records = records.map(&:fqdn)
-          .select { |record| record.match?(/^([a-zA-Z0-9-_]+)#{Regexp.escape(suffix)}$/) }
+          .select { |record| record.match?(/^([a-zA-Z0-9\-_]+)#{Regexp.escape(suffix)}$/) }
         terminal_records.each do |terminal_record|
           non_terminal = terminal_record.partition('.').last
           errors.add(:records, "found empty non-terminal #{non_terminal} "\


### PR DESCRIPTION
we were getting...
`zone.rb:270: warning: character class has '-' without escape: /^([a-zA-Z0-9-_]+\.[a-zA-Z0-9-_])\.api\.shopify\.io\.$/`

the regex does in fact have a small bug, although I can't reproduce the warning

this PR fixes the regex(es) by escaping the standalone hyphens