### PR TITLE
Handle NS1 Unparseable Responses

### DIFF
--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -158,8 +158,7 @@ module RecordStore
             raise if max_retries <= 0
             max_retries -= 1
 
-            waiter.message = "Waiting to retry after receiving an unparseable response"
-            waiter.wait
+            waiter.wait("Waiting to retry after receiving an unparseable response")
           rescue Net::OpenTimeout, Errno::ETIMEDOUT
             raise if max_timeouts <= 0
             max_timeouts -= 1

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -3,7 +3,7 @@ require 'resolv'
 module RecordStore
   class Provider
     class Error < StandardError; end
-    class UnavailableError < Error; end
+    class UnparseableBodyError < Error; end
 
     class << self
       def provider_for(object)
@@ -154,10 +154,11 @@ module RecordStore
         loop do
           begin
             return yield
-          rescue UnavailableError
+          rescue UnparseableBodyError
             raise if max_retries <= 0
             max_retries -= 1
 
+            waiter.message = "Waiting to retry since provider is unavailable"
             waiter.wait
           rescue Net::OpenTimeout, Errno::ETIMEDOUT
             raise if max_timeouts <= 0

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -3,7 +3,7 @@ require 'resolv'
 module RecordStore
   class Provider
     class Error < StandardError; end
-    class ProviderUnavailableError < Error; end
+    class UnavailableError < Error; end
 
     class << self
       def provider_for(object)
@@ -154,7 +154,7 @@ module RecordStore
         loop do
           begin
             return yield
-          rescue ProviderUnavailableError
+          rescue UnavailableError
             raise if max_retries <= 0
             max_retries -= 1
 

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -145,7 +145,7 @@ module RecordStore
         max_backoff: 10
       )
         waiter = BackoffWaiter.new(
-          "Waiting to retry after a connection reset",
+          'Waiting to retry after a connection reset',
           initial_delay: delay,
           multiplier: backoff_multiplier,
           max_delay: max_backoff,
@@ -158,12 +158,12 @@ module RecordStore
             raise if max_retries <= 0
             max_retries -= 1
 
-            waiter.wait("Waiting to retry after receiving an unparseable response")
+            waiter.wait(message: 'Waiting to retry after receiving an unparseable response')
           rescue Net::OpenTimeout, Errno::ETIMEDOUT
             raise if max_timeouts <= 0
             max_timeouts -= 1
 
-            $stderr.puts("Retrying after a connection timeout")
+            $stderr.puts('Retrying after a connection timeout')
           rescue Errno::ECONNRESET
             raise if max_conn_resets <= 0
             max_conn_resets -= 1

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -158,7 +158,7 @@ module RecordStore
             raise if max_retries <= 0
             max_retries -= 1
 
-            waiter.message = "Waiting to retry since provider is unavailable"
+            waiter.message = "Waiting to retry after receiving an unparseable response"
             waiter.wait
           rescue Net::OpenTimeout, Errno::ETIMEDOUT
             raise if max_timeouts <= 0

--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -3,7 +3,7 @@ require_relative 'ns1/patch_api_header'
 
 module RecordStore
   class Provider::NS1 < Provider
-    class Error < StandardError; end
+    # class Error < StandardError; end
 
     class ApiAnswer
       class << self
@@ -180,7 +180,7 @@ module RecordStore
         unless updated
           error = +'while trying to update a record, could not find answer with fqdn: '
           error << "#{record.fqdn}, type; #{record.type}, id: #{id}"
-          raise Error, error
+          raise RecordStore::Provider::Error, error
         end
 
         client.modify_record(

--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -3,8 +3,6 @@ require_relative 'ns1/patch_api_header'
 
 module RecordStore
   class Provider::NS1 < Provider
-    # class Error < StandardError; end
-
     class ApiAnswer
       class << self
         def from_full_api_answer(type:, record_id:, answer:)

--- a/lib/record_store/provider/ns1/client.rb
+++ b/lib/record_store/provider/ns1/client.rb
@@ -49,7 +49,7 @@ module RecordStore
 
       def raise_error(result)
         if Net::HTTPResponse::CODE_TO_OBJ[result.status.to_s] == Net::HTTPServiceUnavailable
-          raise RecordStore::Provider::ProviderUnavailableError, result.to_s
+          raise RecordStore::Provider::UnavailableError, result.to_s
         end
         raise RecordStore::Provider::Error, result.to_s
       end

--- a/lib/record_store/provider/ns1/client.rb
+++ b/lib/record_store/provider/ns1/client.rb
@@ -48,7 +48,7 @@ module RecordStore
       private
 
       def raise_if_error!(result)
-        return nil unless result.is_a?(NS1::Response::Error)
+        return unless result.is_a?(NS1::Response::Error)
         if result.is_a?(NS1::Response::UnparsableBodyError)
           raise RecordStore::Provider::UnparseableBodyError, result.to_s
         end

--- a/lib/record_store/provider/ns1/client.rb
+++ b/lib/record_store/provider/ns1/client.rb
@@ -48,8 +48,8 @@ module RecordStore
       private
 
       def raise_error(result)
-        if Net::HTTPResponse::CODE_TO_OBJ[result.status.to_s] == Net::HTTPServiceUnavailable
-          raise RecordStore::Provider::UnavailableError, result.to_s
+        if result.is_a?(NS1::Response::UnparsableBodyError)
+          raise RecordStore::Provider::UnparseableBodyError, result.to_s
         end
         raise RecordStore::Provider::Error, result.to_s
       end

--- a/lib/record_store/provider/ns1/client.rb
+++ b/lib/record_store/provider/ns1/client.rb
@@ -1,6 +1,5 @@
 require 'net/http'
 require 'ns1'
-require 'logger'
 
 module RecordStore
   class Provider::NS1 < Provider

--- a/lib/record_store/provider/ns1/client.rb
+++ b/lib/record_store/provider/ns1/client.rb
@@ -10,44 +10,44 @@ module RecordStore
 
       def zones
         zones = super
-        raise_on_error(zones)
+        raise_if_error!(zones)
         zones
       end
 
       def zone(name)
         zone = super(name)
-        raise_on_error(zone)
+        raise_if_error!(zone)
         zone
       end
 
       def record(zone:, fqdn:, type:, must_exist: false)
         result = super(zone, fqdn, type)
-        raise_on_error(result) if must_exist
+        raise_if_error!(result) if must_exist
         return nil if result.is_a?(NS1::Response::Error)
         result
       end
 
       def create_record(zone:, fqdn:, type:, params:)
         result = super(zone, fqdn, type, params)
-        raise_on_error(result)
+        raise_if_error!(result)
         nil
       end
 
       def modify_record(zone:, fqdn:, type:, params:)
         result = super(zone, fqdn, type, params)
-        raise_on_error(result)
+        raise_if_error!(result)
         nil
       end
 
       def delete_record(zone:, fqdn:, type:)
         result = super(zone, fqdn, type)
-        raise_on_error(result)
+        raise_if_error!(result)
         nil
       end
 
       private
 
-      def raise_on_error(result)
+      def raise_if_error!(result)
         return nil unless result.is_a?(NS1::Response::Error)
         if result.is_a?(NS1::Response::UnparsableBodyError)
           raise RecordStore::Provider::UnparseableBodyError, result.to_s

--- a/lib/record_store/provider/ns1/client.rb
+++ b/lib/record_store/provider/ns1/client.rb
@@ -22,8 +22,10 @@ module RecordStore
 
       def record(zone:, fqdn:, type:, must_exist: false)
         result = super(zone, fqdn, type)
-        raise_error(result) if must_exist && result.is_a?(NS1::Response::Error)
-        return nil if result.is_a?(NS1::Response::Error)
+        if result.is_a?(NS1::Response::Error)
+          raise_error(result) if must_exist
+          return nil
+        end
         result
       end
 

--- a/lib/record_store/provider/ns1/client.rb
+++ b/lib/record_store/provider/ns1/client.rb
@@ -10,46 +10,45 @@ module RecordStore
 
       def zones
         zones = super
-        raise_error(zones) if zones.is_a?(NS1::Response::Error)
+        raise_on_error(zones)
         zones
       end
 
       def zone(name)
         zone = super(name)
-        raise_error(zone) if zone.is_a?(NS1::Response::Error)
+        raise_on_error(zone)
         zone
       end
 
       def record(zone:, fqdn:, type:, must_exist: false)
         result = super(zone, fqdn, type)
-        if result.is_a?(NS1::Response::Error)
-          raise_error(result) if must_exist
-          return nil
-        end
+        raise_on_error(result) if must_exist
+        return nil if result.is_a?(NS1::Response::Error)
         result
       end
 
       def create_record(zone:, fqdn:, type:, params:)
         result = super(zone, fqdn, type, params)
-        raise_error(result) if result.is_a?(NS1::Response::Error)
+        raise_on_error(result)
         nil
       end
 
       def modify_record(zone:, fqdn:, type:, params:)
         result = super(zone, fqdn, type, params)
-        raise_error(result) if result.is_a?(NS1::Response::Error)
+        raise_on_error(result)
         nil
       end
 
       def delete_record(zone:, fqdn:, type:)
         result = super(zone, fqdn, type)
-        raise_error(result) if result.is_a?(NS1::Response::Error)
+        raise_on_error(result)
         nil
       end
 
       private
 
-      def raise_error(result)
+      def raise_on_error(result)
+        return nil unless result.is_a?(NS1::Response::Error)
         if result.is_a?(NS1::Response::UnparsableBodyError)
           raise RecordStore::Provider::UnparseableBodyError, result.to_s
         end

--- a/lib/record_store/provider/ns1/patch_api_header.rb
+++ b/lib/record_store/provider/ns1/patch_api_header.rb
@@ -18,6 +18,10 @@ module NS1::Transport
         rate_limit.wait(sleep_time)
       end
 
+      if Net::HTTPResponse::CODE_TO_OBJ[response.code] == Net::HTTPServiceUnavailable
+        return NS1::Response::Error.new({}, response.code.to_i)
+      end
+
       body = JSON.parse(response.body)
       case response
       when Net::HTTPOK

--- a/lib/record_store/provider/provider_utils/waiter.rb
+++ b/lib/record_store/provider/provider_utils/waiter.rb
@@ -5,7 +5,7 @@ class Waiter
 
   attr_accessor :message
 
-  def wait(sleep_time, message = @message)
+  def wait(sleep_time, message: @message)
     while sleep_time > 0
       wait_time = [10, sleep_time].min
       puts "#{message} (#{sleep_time}s left)" if wait_time > 1
@@ -34,8 +34,8 @@ class BackoffWaiter < Waiter
     @current_delay = @initial_delay
   end
 
-  def wait(message = @message)
-    super(@current_delay, message)
+  def wait(message: @message)
+    super(@current_delay, message: message)
     @current_delay = [@current_delay * @multiplier, @max_delay].compact.min
   end
 end

--- a/lib/record_store/provider/provider_utils/waiter.rb
+++ b/lib/record_store/provider/provider_utils/waiter.rb
@@ -5,7 +5,7 @@ class Waiter
 
   attr_accessor :message
 
-  def wait(sleep_time)
+  def wait(sleep_time, message = @message)
     while sleep_time > 0
       wait_time = [10, sleep_time].min
       puts "#{message} (#{sleep_time}s left)" if wait_time > 1
@@ -34,8 +34,8 @@ class BackoffWaiter < Waiter
     @current_delay = @initial_delay
   end
 
-  def wait
-    super(@current_delay)
+  def wait(message = @message)
+    super(@current_delay, message)
     @current_delay = [@current_delay * @multiplier, @max_delay].compact.min
   end
 end

--- a/test/fixtures/vcr_cassettes/ns1_update_changeset_where_response_is_unparseable.yml
+++ b/test/fixtures/vcr_cassettes/ns1_update_changeset_where_response_is_unparseable.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_update_changeset_where_service_is_unavailable.test.recordstore.io/A
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_apply_changeset_where_response_is_unparseable.test.recordstore.io/A
     body:
       encoding: US-ASCII
       string: ''
@@ -60,10 +60,10 @@ http_interactions:
   recorded_at: Fri, 22 Nov 2019 16:39:00 GMT
 - request:
     method: put
-    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_update_changeset_where_service_is_unavailable.test.recordstore.io/A
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_apply_changeset_where_response_is_unparseable.test.recordstore.io/A
     body:
       encoding: UTF-8
-      string: '{"answers":[{"answer":["10.10.10.48"]}],"ttl":600,"zone":"test.recordstore.io","domain":"test_update_changeset_where_service_is_unavailable.test.recordstore.io","type":"A"}'
+      string: '{"answers":[{"answer":["10.10.10.48"]}],"ttl":600,"zone":"test.recordstore.io","domain":"test_apply_changeset_where_response_is_unparseable.test.recordstore.io","type":"A"}'
     headers:
       X-Nsone-Key:
       - "<NS1_API_KEY>"

--- a/test/fixtures/vcr_cassettes/ns1_update_changeset_where_service_is_unavailable.yml
+++ b/test/fixtures/vcr_cassettes/ns1_update_changeset_where_service_is_unavailable.yml
@@ -1,0 +1,132 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_update_changeset_where_service_is_unavailable.test.recordstore.io/A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 503
+      message: Service Unavailable
+    headers:
+      Date:
+      - Fri, 22 Nov 2019 16:39:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '31'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d14eb814416d783567c4a9996f516c36e1574440754; expires=Sun, 22-Dec-19
+        16:39:14 GMT; path=/; domain=.nsone.net; HttpOnly
+      X-Ratelimit-Remaining:
+      - '899'
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '900'
+      X-Ratelimit-Period:
+      - '300'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - '0'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 539c5698d8a8cabc-YYZ
+    body:
+      encoding: UTF-8
+      string: '<!DOCTYPE html> <title>Temporarily unavailable | api.nsone.net | Cloudflare</title>'
+    http_version: 
+  recorded_at: Fri, 22 Nov 2019 16:39:00 GMT
+- request:
+    method: put
+    uri: https://api.nsone.net/v1/zones/test.recordstore.io/test_update_changeset_where_service_is_unavailable.test.recordstore.io/A
+    body:
+      encoding: UTF-8
+      string: '{"answers":[{"answer":["10.10.10.48"]}],"ttl":600,"zone":"test.recordstore.io","domain":"test_update_changeset_where_service_is_unavailable.test.recordstore.io","type":"A"}'
+    headers:
+      X-Nsone-Key:
+      - "<NS1_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 503
+      message: Service Unavailable
+    headers:
+      Date:
+      - Fri, 22 Nov 2019 16:39:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dc4af046d5915772e1cf5e06db92337b91574440754; expires=Sun, 22-Dec-19
+        16:39:14 GMT; path=/; domain=.nsone.net; HttpOnly
+      X-Ratelimit-Remaining:
+      - '99'
+      X-Ratelimit-By:
+      - customer
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Period:
+      - '200'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      - private, max-age=0, no-cache, no-store
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 539c569bbfb2ab9a-YYZ
+    body:
+      encoding: ASCII-8BIT
+      string: '{"domain":"test_update_changeset_where_service_is_unavailable.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["10.10.10.48"],"id":"5dd80f32c94a900001e474d4"}],"id":"5dd80f32c94a900001e474d5","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"A","networks":[0]}
+
+        '
+    http_version: 
+  recorded_at: Fri, 22 Nov 2019 16:39:01 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/ns1_update_changeset_where_service_is_unavailable.yml
+++ b/test/fixtures/vcr_cassettes/ns1_update_changeset_where_service_is_unavailable.yml
@@ -123,10 +123,8 @@ http_interactions:
       Cf-Ray:
       - 539c569bbfb2ab9a-YYZ
     body:
-      encoding: ASCII-8BIT
-      string: '{"domain":"test_update_changeset_where_service_is_unavailable.test.recordstore.io","zone":"test.recordstore.io","use_client_subnet":true,"answers":[{"answer":["10.10.10.48"],"id":"5dd80f32c94a900001e474d4"}],"id":"5dd80f32c94a900001e474d5","regions":{},"meta":{},"link":null,"filters":[],"ttl":600,"tier":1,"type":"A","networks":[0]}
-
-        '
+      encoding: UTF-8
+      string: '<!DOCTYPE html> <title>Temporarily unavailable | api.nsone.net | Cloudflare</title>'
     http_version: 
   recorded_at: Fri, 22 Nov 2019 16:39:01 GMT
 recorded_with: VCR 4.0.0

--- a/test/providers/ns1_connection_errors_test.rb
+++ b/test/providers/ns1_connection_errors_test.rb
@@ -112,7 +112,7 @@ class NS1ConnectionErrorsTest < Minitest::Test
       )
       .times(5)
 
-    assert_raises(RecordStore::Provider::UnavailableError) do
+    assert_raises(RecordStore::Provider::UnparseableBodyError) do
       @ns1.zones
     end
   end

--- a/test/providers/ns1_connection_errors_test.rb
+++ b/test/providers/ns1_connection_errors_test.rb
@@ -100,4 +100,20 @@ class NS1ConnectionErrorsTest < Minitest::Test
       @ns1.zones
     end
   end
+
+  def test_zones_raises_after_too_many_retries
+    BackoffWaiter.any_instance.stubs(:wait)
+    BackoffWaiter.any_instance.expects(:wait).times(5)
+
+    stub_request(:get, "https://api.nsone.net/v1/zones")
+      .to_return(
+        body: '<!DOCTYPE html> <title>Temporarily unavailable | api.nsone.net | Cloudflare</title>',
+        status: 503
+      )
+      .times(5)
+
+    assert_raises(RecordStore::Provider::ProviderUnavailableError) do
+      @ns1.zones
+    end
+  end
 end

--- a/test/providers/ns1_connection_errors_test.rb
+++ b/test/providers/ns1_connection_errors_test.rb
@@ -101,7 +101,7 @@ class NS1ConnectionErrorsTest < Minitest::Test
     end
   end
 
-  def test_zones_raises_after_too_many_retries
+  def test_zones_raises_after_too_many_unparseable_responses
     BackoffWaiter.any_instance.stubs(:wait)
     BackoffWaiter.any_instance.expects(:wait).times(5)
 

--- a/test/providers/ns1_connection_errors_test.rb
+++ b/test/providers/ns1_connection_errors_test.rb
@@ -112,7 +112,7 @@ class NS1ConnectionErrorsTest < Minitest::Test
       )
       .times(5)
 
-    assert_raises(RecordStore::Provider::ProviderUnavailableError) do
+    assert_raises(RecordStore::Provider::UnavailableError) do
       @ns1.zones
     end
   end

--- a/test/providers/ns1_test.rb
+++ b/test/providers/ns1_test.rb
@@ -158,11 +158,11 @@ class NS1Test < Minitest::Test
     end
   end
 
-  def test_apply_changeset_where_service_is_unavailable
-    VCR.use_cassette('ns1_update_changeset_where_service_is_unavailable') do
+  def test_apply_changeset_where_response_is_unparseable
+    VCR.use_cassette('ns1_update_changeset_where_response_is_unparseable') do
       record_data = {
         address: '10.10.10.48',
-        fqdn: 'test_update_changeset_where_service_is_unavailable.test.recordstore.io',
+        fqdn: 'test_apply_changeset_where_response_is_unparseable.test.recordstore.io',
         ttl: 600,
       }
 

--- a/test/providers/ns1_test.rb
+++ b/test/providers/ns1_test.rb
@@ -168,7 +168,7 @@ class NS1Test < Minitest::Test
 
       # Create a record
       record = Record::A.new(record_data)
-      assert_raises(RecordStore::Provider::ProviderUnavailableError) do
+      assert_raises(RecordStore::Provider::UnavailableError) do
         @ns1.apply_changeset(Changeset.new(
           current_records: [],
           desired_records: [record],

--- a/test/providers/ns1_test.rb
+++ b/test/providers/ns1_test.rb
@@ -158,6 +158,27 @@ class NS1Test < Minitest::Test
     end
   end
 
+  def test_apply_changeset_where_service_is_unavailable
+    VCR.use_cassette('ns1_update_changeset_where_service_is_unavailable') do
+      record_data = {
+        address: '10.10.10.48',
+        fqdn: 'test_update_changeset_where_service_is_unavailable.test.recordstore.io',
+        ttl: 600,
+      }
+
+      # Create a record
+      record = Record::A.new(record_data)
+      assert_raises(RecordStore::Provider::ProviderUnavailableError) do
+        @ns1.apply_changeset(Changeset.new(
+          current_records: [],
+          desired_records: [record],
+          provider: @ns1,
+          zone: @zone_name
+        ))
+      end
+    end
+  end
+
   def test_update_changeset_for_fqdn_with_multiple_answers
     VCR.use_cassette('ns1_update_changeset_for_fqdn_with_multiple_answers') do
       base_record_data = {

--- a/test/providers/ns1_test.rb
+++ b/test/providers/ns1_test.rb
@@ -168,7 +168,7 @@ class NS1Test < Minitest::Test
 
       # Create a record
       record = Record::A.new(record_data)
-      assert_raises(RecordStore::Provider::UnavailableError) do
+      assert_raises(RecordStore::Provider::UnparseableBodyError) do
         @ns1.apply_changeset(Changeset.new(
           current_records: [],
           desired_records: [record],


### PR DESCRIPTION
### Problem
NS1 returns an HTML body with a 503 status (service unavailable). `NS1:Client` tries to parse the HTML body as a JSON, which throws an uncaught error.

Related to #179 

### Solution
Create a new error type `RecordStore::Provider::ProviderUnavailableError` which is raised when NS1 returns a 503 status. If the error is raised within `RecordStore::Provider#retry_on_connection_errors`, then the connection will be retried several times.