### PR TITLE
Explicitly depend on rubocop-0.89.1

### DIFF
--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -48,6 +48,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '0.89.1'
   spec.add_development_dependency 'minitest-focus'
 end

--- a/test/changeset_test.rb
+++ b/test/changeset_test.rb
@@ -177,10 +177,10 @@ class ChangesetTest < Minitest::Test
     VCR.use_cassette('dynect_retrieve_current_records') do
       changeset = Changeset.build_from(provider: zone.providers[0], zone: zone)
 
-      assert_equal 1, changeset.removals.length
-      assert_kind_of Record::ALIAS, changeset.removals[0].record
-      assert_predicate changeset.additions, :empty?
-      refute_predicate changeset.unchanged, :empty?
+      assert_equal(1, changeset.removals.length)
+      assert_kind_of(Record::ALIAS, changeset.removals[0].record)
+      assert_predicate(changeset.additions, :empty?)
+      refute_predicate(changeset.unchanged, :empty?)
     end
   end
 
@@ -223,9 +223,9 @@ class ChangesetTest < Minitest::Test
     VCR.use_cassette('dynect_retrieve_current_records') do
       changeset = Changeset.build_from(provider: zone.providers[0], zone: zone)
 
-      assert_predicate changeset.removals, :empty?
-      assert_predicate changeset.additions, :empty?
-      refute_predicate changeset.unchanged, :empty?
+      assert_predicate(changeset.removals, :empty?)
+      assert_predicate(changeset.additions, :empty?)
+      refute_predicate(changeset.unchanged, :empty?)
     end
   end
 
@@ -268,10 +268,10 @@ class ChangesetTest < Minitest::Test
     VCR.use_cassette('dynect_retrieve_current_records') do
       changeset = Changeset.build_from(provider: zone.providers[0], zone: zone, all: true)
 
-      assert_equal 1, changeset.removals.length
-      assert_kind_of Record::NS, changeset.removals[0].record
-      assert_predicate changeset.additions, :empty?
-      refute_predicate changeset.unchanged, :empty?
+      assert_equal(1, changeset.removals.length)
+      assert_kind_of(Record::NS, changeset.removals[0].record)
+      assert_predicate(changeset.additions, :empty?)
+      refute_predicate(changeset.unchanged, :empty?)
     end
   end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -26,7 +26,7 @@ class CLITest < Minitest::Test
 
       RecordStore::CLI.start("secrets -c #{config_path}".split(' '))
 
-      assert_equal secrets_ejson, File.read(RecordStore.secrets_path)
+      assert_equal(secrets_ejson, File.read(RecordStore.secrets_path))
     end
 
   ensure

--- a/test/providers/dnsimple_test.rb
+++ b/test/providers/dnsimple_test.rb
@@ -371,8 +371,8 @@ class DNSimpleTest < Minitest::Test
       ))
 
       records = @dnsimple.retrieve_current_records(zone: @zone_name)
-      refute_includes records.map(&:type), 'TXT'
-      assert_includes records.map(&:type), 'ALIAS'
+      refute_includes(records.map(&:type), 'TXT')
+      assert_includes(records.map(&:type), 'ALIAS')
     end
   end
 
@@ -424,7 +424,7 @@ class DNSimpleTest < Minitest::Test
 
     VCR.use_cassette('dnsimple_retrieve_current_records') do
       records = @dnsimple.retrieve_current_records(zone: @zone_name)
-      assert_equal records_arr.sort_by(&:to_s), records.sort_by(&:to_s)
+      assert_equal(records_arr.sort_by(&:to_s), records.sort_by(&:to_s))
     end
   end
 
@@ -479,7 +479,7 @@ class DNSimpleTest < Minitest::Test
 
   def test_zones_returns_list_of_zones_managed_by_provider
     VCR.use_cassette('dnsimple_zones') do
-      assert_equal @dnsimple.zones, [@zone_name]
+      assert_equal(@dnsimple.zones, [@zone_name])
     end
   end
 
@@ -499,7 +499,7 @@ class DNSimpleTest < Minitest::Test
     session.expects(:rate_limit_sleep).with(rate_limit_reset, rate_limit_remaining)
 
     VCR.use_cassette('dnsimple_zones') do
-      assert_equal @dnsimple.zones, [@zone_name]
+      assert_equal(@dnsimple.zones, [@zone_name])
     end
   end
 

--- a/test/providers/dynect_test.rb
+++ b/test/providers/dynect_test.rb
@@ -309,7 +309,7 @@ class DynECTTest < Minitest::Test
 
     VCR.use_cassette('dynect_retrieve_current_records') do
       records = Provider::DynECT.retrieve_current_records(zone: @zone_name)
-      assert_equal records_arr, records
+      assert_equal(records_arr, records)
     end
   end
 
@@ -330,7 +330,7 @@ class DynECTTest < Minitest::Test
 
   def test_zones_returns_list_of_zones_managed_by_provider
     VCR.use_cassette('dynect_zones') do
-      assert_equal Provider::DynECT.zones, [@zone_name]
+      assert_equal(Provider::DynECT.zones, [@zone_name])
     end
   end
 

--- a/test/providers/google_cloud_dns_test.rb
+++ b/test/providers/google_cloud_dns_test.rb
@@ -290,13 +290,13 @@ class GoogleCloudDNSTest < Minitest::Test
 
     VCR.use_cassette('gcloud_dns_retrieve_current_records') do
       records = Provider::GoogleCloudDNS.retrieve_current_records(zone: 'dns-scratch.me').sort_by(&:to_s)
-      assert_equal records_arr, records
+      assert_equal(records_arr, records)
     end
   end
 
   def test_zones_returns_list_of_zones_managed_by_provider
     VCR.use_cassette('gcloud_dns_zones') do
-      assert_equal Provider::GoogleCloudDNS.zones, ['dns-scratch.me.']
+      assert_equal(Provider::GoogleCloudDNS.zones, ['dns-scratch.me.'])
     end
   end
 

--- a/test/providers/ns1_test.rb
+++ b/test/providers/ns1_test.rb
@@ -69,7 +69,7 @@ class NS1Test < Minitest::Test
           record.address == current_record.address
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -93,7 +93,7 @@ class NS1Test < Minitest::Test
 
       # Retrieve it
       record = @ns1.retrieve_current_records(zone: @zone_name).select { |r| r == record }.first
-      assert !record.nil?
+      assert(!record.nil?)
 
       updated_record = Record::A.new(record_data)
       updated_record.address = "10.10.10.49"
@@ -109,8 +109,8 @@ class NS1Test < Minitest::Test
       updated_record_exists = @ns1.retrieve_current_records(zone: @zone_name).any? { |r| r == updated_record }
       old_record_does_not_exist = @ns1.retrieve_current_records(zone: @zone_name).none? { |r| r == record }
 
-      assert updated_record_exists
-      assert old_record_does_not_exist
+      assert(updated_record_exists)
+      assert(old_record_does_not_exist)
     end
   end
 
@@ -134,7 +134,7 @@ class NS1Test < Minitest::Test
 
       # Retrieve it
       record = @ns1.retrieve_current_records(zone: @zone_name).select { |r| r == record }.first
-      assert !record.nil?
+      assert(!record.nil?)
 
       updated_record = Record::A.new(record_data)
       updated_record.address = "10.10.10.49"
@@ -233,10 +233,10 @@ class NS1Test < Minitest::Test
       second_record_exists = @ns1.retrieve_current_records(zone: @zone_name).any? { |r| r == original_records[1] }
       third_record_exists = @ns1.retrieve_current_records(zone: @zone_name).any? { |r| r == original_records[2] }
 
-      assert updated_record_exists
-      assert first_record_does_not_exist
-      assert second_record_exists
-      assert third_record_exists
+      assert(updated_record_exists)
+      assert(first_record_does_not_exist)
+      assert(second_record_exists)
+      assert(third_record_exists)
     end
   end
 
@@ -248,7 +248,7 @@ class NS1Test < Minitest::Test
     )
 
     VCR.use_cassette('ns1_add_changeset_nil_zone') do
-      assert_raises NS1::MissingParameter do
+      assert_raises(NS1::MissingParameter) do
         @ns1.apply_changeset(Changeset.new(
           current_records: [],
           desired_records: [record],
@@ -294,7 +294,7 @@ class NS1Test < Minitest::Test
           record.address == current_record.address
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -324,7 +324,7 @@ class NS1Test < Minitest::Test
 
       contains_updated_record = current_records.any? { |r| r == record_with_updated_ttl }
 
-      assert contains_updated_record
+      assert(contains_updated_record)
     end
   end
 
@@ -347,7 +347,7 @@ class NS1Test < Minitest::Test
           record.alias == current_record.alias
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -376,7 +376,7 @@ class NS1Test < Minitest::Test
           record.value == current_record.value
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -399,7 +399,7 @@ class NS1Test < Minitest::Test
           record.cname == current_record.cname
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -428,7 +428,7 @@ class NS1Test < Minitest::Test
           record.exchange == current_record.exchange
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -451,7 +451,7 @@ class NS1Test < Minitest::Test
         record.nsdname == current_record.nsdname
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -473,7 +473,7 @@ class NS1Test < Minitest::Test
           record.ttl == current_record.ttl &&
           record.txtdata == current_record.txtdata
       end
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -495,7 +495,7 @@ class NS1Test < Minitest::Test
           record.ttl == current_record.ttl &&
           record.txtdata == current_record.txtdata
       end
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -527,7 +527,7 @@ class NS1Test < Minitest::Test
           record.port == current_record.port &&
           record.target == current_record.target
       end
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -564,8 +564,8 @@ class NS1Test < Minitest::Test
           record_1.address == current_record.address
       end
 
-      assert record_2_missing, "expected deleted record to be absent in NS1"
-      assert record_1_found, "expected record that was not removed to be present in NS1"
+      assert(record_2_missing, "expected deleted record to be absent in NS1")
+      assert(record_1_found, "expected record that was not removed to be present in NS1")
     end
   end
 
@@ -590,8 +590,8 @@ class NS1Test < Minitest::Test
         record.fqdn == imported_txt_record.fqdn
       end
 
-      assert_equal 1, matching_records.size, "could not find the record that was just imported"
-      assert_equal imported_txt_record.txtdata, matching_records.first.txtdata
+      assert_equal(1, matching_records.size, "could not find the record that was just imported")
+      assert_equal(imported_txt_record.txtdata, matching_records.first.txtdata)
     end
   end
 
@@ -616,8 +616,8 @@ class NS1Test < Minitest::Test
         record.fqdn == imported_txt_record.fqdn
       end
 
-      assert_equal 1, matching_records.size, 'could not find the record that was just imported'
-      assert_equal matching_records.first.txtdata, 'v=DKIM\; k=rsa\;'
+      assert_equal(1, matching_records.size, 'could not find the record that was just imported')
+      assert_equal(matching_records.first.txtdata, 'v=DKIM\; k=rsa\;')
     end
   end
 
@@ -646,8 +646,8 @@ class NS1Test < Minitest::Test
         record.fqdn == imported_txt_record.fqdn
       end
 
-      assert_equal 1, matching_records.size, 'could not find the record that was just imported'
-      assert_equal matching_records.first.txtdata, txtdata
+      assert_equal(1, matching_records.size, 'could not find the record that was just imported')
+      assert_equal(matching_records.first.txtdata, txtdata)
     end
   end
 

--- a/test/providers/oracle_cloud_dns_test.rb
+++ b/test/providers/oracle_cloud_dns_test.rb
@@ -63,7 +63,7 @@ class OracleCloudDNSTest < Minitest::Test
           records[0].ttl == current_record.ttl &&
           records[0].txtdata == current_record.txtdata
       end
-      assert contains_desired_record.length == 1
+      assert(contains_desired_record.length == 1)
     end
   end
 
@@ -75,7 +75,7 @@ class OracleCloudDNSTest < Minitest::Test
     )
 
     VCR.use_cassette('oracle_add_changeset_nil_zone') do
-      assert_raises RuntimeError do
+      assert_raises(RuntimeError) do
         @oracle_cloud_dns.apply_changeset(Changeset.new(
           current_records: [],
           desired_records: [record],
@@ -130,7 +130,7 @@ class OracleCloudDNSTest < Minitest::Test
           record.ttl == current_record.ttl &&
           record.address == current_record.address
       end
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -156,7 +156,7 @@ class OracleCloudDNSTest < Minitest::Test
           record.ttl == current_record.ttl &&
           record.address == current_record.address
       end
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -196,7 +196,7 @@ class OracleCloudDNSTest < Minitest::Test
           records[1].ttl == current_record.ttl &&
           records[1].address == current_record.address
       end
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -236,7 +236,7 @@ class OracleCloudDNSTest < Minitest::Test
           records[1].ttl == current_record.ttl &&
           records[1].txtdata == current_record.txtdata
       end
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -276,7 +276,7 @@ class OracleCloudDNSTest < Minitest::Test
           records[0].ttl == current_record.ttl &&
           records[0].txtdata == current_record.txtdata
       end
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -299,7 +299,7 @@ class OracleCloudDNSTest < Minitest::Test
           record.address == current_record.address
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -322,7 +322,7 @@ class OracleCloudDNSTest < Minitest::Test
           record.alias == current_record.alias
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -351,7 +351,7 @@ class OracleCloudDNSTest < Minitest::Test
           record.value == current_record.value
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -374,7 +374,7 @@ class OracleCloudDNSTest < Minitest::Test
           record.cname == current_record.cname
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -403,7 +403,7 @@ class OracleCloudDNSTest < Minitest::Test
           record.exchange == current_record.exchange
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -429,7 +429,7 @@ class OracleCloudDNSTest < Minitest::Test
         record.nsdname == current_record.nsdname
       end
 
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -452,7 +452,7 @@ class OracleCloudDNSTest < Minitest::Test
           record.ttl == current_record.ttl &&
           record.txtdata == current_record.txtdata
       end
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -474,7 +474,7 @@ class OracleCloudDNSTest < Minitest::Test
           record.ttl == current_record.ttl &&
           record.txtdata == current_record.txtdata
       end
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -506,7 +506,7 @@ class OracleCloudDNSTest < Minitest::Test
           record.port == current_record.port &&
           record.target == current_record.target
       end
-      assert contains_desired_record
+      assert(contains_desired_record)
     end
   end
 
@@ -530,7 +530,7 @@ class OracleCloudDNSTest < Minitest::Test
 
       # Retrieve it
       record = @oracle_cloud_dns.retrieve_current_records(zone: @zone_name).select { |r| r == record }.first
-      assert !record.nil?
+      assert(!record.nil?)
 
       updated_record = Record::A.new(record_data)
       updated_record.address = "10.10.10.49"
@@ -550,8 +550,8 @@ class OracleCloudDNSTest < Minitest::Test
         zone: @zone_name
       ).none? { |r| r == record }
 
-      assert updated_record_exists
-      assert old_record_does_not_exist
+      assert(updated_record_exists)
+      assert(old_record_does_not_exist)
     end
   end
 
@@ -581,7 +581,7 @@ class OracleCloudDNSTest < Minitest::Test
 
       contains_updated_record = current_records.any? { |r| r == record_with_updated_ttl }
 
-      assert contains_updated_record
+      assert(contains_updated_record)
     end
   end
 
@@ -605,7 +605,7 @@ class OracleCloudDNSTest < Minitest::Test
 
       # Retrieve it
       record = @oracle_cloud_dns.retrieve_current_records(zone: @zone_name).select { |r| r == record }.first
-      assert !record.nil?
+      assert(!record.nil?)
 
       updated_record = Record::A.new(record_data)
       updated_record.address = "10.10.10.49"
@@ -686,10 +686,10 @@ class OracleCloudDNSTest < Minitest::Test
         zone: @zone_name
       ).any? { |r| r == original_records[2] }
 
-      assert updated_record_exists
-      assert first_record_does_not_exist
-      assert second_record_exists
-      assert third_record_exists
+      assert(updated_record_exists)
+      assert(first_record_does_not_exist)
+      assert(second_record_exists)
+      assert(third_record_exists)
     end
   end
 
@@ -726,8 +726,8 @@ class OracleCloudDNSTest < Minitest::Test
           record_1.address == current_record.address
       end
 
-      assert record_2_missing, "expected deleted record to be absent in Oracle"
-      assert record_1_found, "expected record that was not removed to be present in Oracle"
+      assert(record_2_missing, "expected deleted record to be absent in Oracle")
+      assert(record_1_found, "expected record that was not removed to be present in Oracle")
     end
   end
 end

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -210,11 +210,11 @@ class ZoneTest < Minitest::Test
       name = 'dns-test.shopify.io'
       VCR.use_cassette('dynect_retrieve_current_records') do
         Zone.download(name, 'DynECT')
-        assert File.exist?("#{RecordStore.zones_path}/#{name}.yml")
+        assert(File.exist?("#{RecordStore.zones_path}/#{name}.yml"))
 
         zone = Zone.find(name)
-        assert_equal [{ type: 'NS', fqdn: "#{name}." }], zone.config.ignore_patterns.map(&:to_hash)
-        assert_equal [
+        assert_equal([{ type: 'NS', fqdn: "#{name}." }], zone.config.ignore_patterns.map(&:to_hash))
+        assert_equal([
           Record::ALIAS.new(
             zone: 'dns-test.shopify.io',
             ttl: 60,
@@ -229,7 +229,7 @@ class ZoneTest < Minitest::Test
             address: '10.10.10.10',
             record_id: 189358987
           ),
-        ], zone.records
+        ], zone.records)
       end
     end
   end
@@ -240,9 +240,9 @@ class ZoneTest < Minitest::Test
       VCR.use_cassette('dnsimple_retrieve_current_records_no_alias') do
         Zone.download(name, 'DNSimple')
       end
-      assert File.exist?("#{RecordStore.zones_path}/#{name}.yml")
+      assert(File.exist?("#{RecordStore.zones_path}/#{name}.yml"))
       zone = Zone.find(name)
-      assert_predicate zone.config, :supports_alias?
+      assert_predicate(zone.config, :supports_alias?)
     end
   end
 
@@ -252,9 +252,9 @@ class ZoneTest < Minitest::Test
       VCR.use_cassette('dynect_retrieve_current_records_no_alias') do
         Zone.download(name, 'DynECT')
       end
-      assert File.exist?("#{RecordStore.zones_path}/#{name}.yml")
+      assert(File.exist?("#{RecordStore.zones_path}/#{name}.yml"))
       zone = Zone.find(name)
-      refute_predicate zone.config, :supports_alias?
+      refute_predicate(zone.config, :supports_alias?)
     end
   end
 
@@ -265,7 +265,7 @@ class ZoneTest < Minitest::Test
         Zone.download(name, 'DynECT')
       end
       zone = Zone.find(name)
-      assert_predicate zone.config, :supports_alias?
+      assert_predicate(zone.config, :supports_alias?)
     end
   end
 
@@ -346,8 +346,8 @@ class ZoneTest < Minitest::Test
 
       zone.write(format: :directory)
 
-      assert Dir.exist?("#{RecordStore.zones_path}/wildcard.com")
-      assert File.exist?("#{RecordStore.zones_path}/wildcard.com/CNAME__*.yml")
+      assert(Dir.exist?("#{RecordStore.zones_path}/wildcard.com"))
+      assert(File.exist?("#{RecordStore.zones_path}/wildcard.com/CNAME__*.yml"))
     end
   end
 
@@ -360,8 +360,8 @@ class ZoneTest < Minitest::Test
 
       zone.write(format: :directory)
 
-      assert Dir.exist?("#{RecordStore.zones_path}/two-records.com")
-      assert File.exist?("#{RecordStore.zones_path}/two-records.com/A__a-records.yml")
+      assert(Dir.exist?("#{RecordStore.zones_path}/two-records.com"))
+      assert(File.exist?("#{RecordStore.zones_path}/two-records.com/A__a-records.yml"))
     end
   end
 


### PR DESCRIPTION
rubocop [has yet to stabilize its APIs](https://github.com/rubocop-hq/rubocop#installation).

This has [time](https://travis-ci.org/github/Shopify/record_store/builds/734378288) and [time](https://travis-ci.org/github/Shopify/record_store/builds/675835977) and [time again](https://travis-ci.org/github/Shopify/record_store/builds/718783368) generated spurious CI/rubocop failures, even if the files found to be in violation were not modified in the PR.

In my view this creates needless busy work for marginal benefit. There is little value in bikeshedding over what a linting rule is called, or which rules must be enabled by default.

Let's pick one set of rules - from `rubocop-0.89.1` - and just roll with it. Once rubocop stabilizes their API we can consider bumping the version.

Also spends time adding parentheses everywhere because rubocop still demands it.