### PR TITLE
Use proper name for implicit_records_templates in Zone::Config

### DIFF
--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.4.0'.freeze
+  VERSION = '6.4.1'.freeze
 end

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -191,7 +191,7 @@ module RecordStore
     def build_records(records)
       all_records = records.map { |record| Record.build_from_yaml_definition(record) }
 
-      config.implicit_record_templates.each do |template|
+      config.implicit_records_templates.each do |template|
         all_records.push(*template.generate_records_to_inject(current_records: all_records))
       end
 

--- a/lib/record_store/zone/config.rb
+++ b/lib/record_store/zone/config.rb
@@ -3,15 +3,15 @@ module RecordStore
     class Config
       include ActiveModel::Validations
 
-      attr_reader :ignore_patterns, :providers, :supports_alias, :implicit_record_templates
+      attr_reader :ignore_patterns, :providers, :supports_alias, :implicit_records_templates
 
       validate :validate_zone_config
 
-      def initialize(ignore_patterns: [], providers: nil, supports_alias: nil, implicit_record_templates: [])
+      def initialize(ignore_patterns: [], providers: nil, supports_alias: nil, implicit_records_templates: [])
         @ignore_patterns = ignore_patterns.map do |ignore_pattern|
           Zone::Config::IgnorePattern.new(ignore_pattern)
         end
-        @implicit_record_templates = implicit_record_templates.map do |filename|
+        @implicit_records_templates = implicit_records_templates.map do |filename|
           Zone::Config::ImplicitRecordTemplate.from_file(filename: filename)
         end
         @providers = providers

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -522,7 +522,7 @@ class ZoneTest < Minitest::Test
   def test_implicit_record_injection_only_injects_for_matching_records
     zone = Zone.new(
       name: 'zone-with-implicit-records.com',
-      config: { providers: ['DynECT'], ignore_patterns: [], implicit_record_templates: ['dummy-implicit.yml.erb'] },
+      config: { providers: ['DynECT'], ignore_patterns: [], implicit_records_templates: ['dummy-implicit.yml.erb'] },
       records: [
         { type: 'A', fqdn: 'a.test.com.', address: '10.10.10.10', ttl: 86400 },
         { type: 'ALIAS', fqdn: 'a.test.alias.com.', alias: 'a.test.com.', ttl: 86400 },
@@ -540,7 +540,7 @@ class ZoneTest < Minitest::Test
   def implicit_record_injection_does_not_inject_template_records_if_they_conflict_with_existing_records
     zone = Zone.new(
       name: 'zone-with-implicit-records.com',
-      config: { providers: ['DynECT'], ignore_patterns: [], implicit_record_templates: ['dummy-implicit.yml.erb'] },
+      config: { providers: ['DynECT'], ignore_patterns: [], implicit_records_templates: ['dummy-implicit.yml.erb'] },
       records: [
         { type: 'A', fqdn: 'a.test.com.', address: '10.10.10.10', ttl: 86400 },
         { type: 'ALIAS', fqdn: 'a.test.alias.com.', alias: 'a.test.com.', ttl: 86400 },
@@ -556,10 +556,10 @@ class ZoneTest < Minitest::Test
     assert_equal(expected, zone.records)
   end
 
-  def implicit_record_injection_does_not_occur_if_no_implicit_record_templates_are_provided
+  def implicit_record_injection_does_not_occur_if_no_implicit_records_templates_are_provided
     zone = Zone.new(
       name: 'zone-with-implicit-records.com',
-      config: { providers: ['DynECT'], ignore_patterns: [], implicit_record_templates: [] },
+      config: { providers: ['DynECT'], ignore_patterns: [], implicit_records_templates: [] },
       records: [
         { type: 'A', fqdn: 'a.test.com.', address: '10.10.10.10', ttl: 86400 },
         { type: 'ALIAS', fqdn: 'a.test.alias.com.', alias: 'a.test.com.', ttl: 86400 },
@@ -658,7 +658,7 @@ class ZoneTest < Minitest::Test
     default_args = {
       providers: ['DynECT'],
       ignore_patterns: [],
-      implicit_record_templates: [],
+      implicit_records_templates: [],
     }
 
     Zone::Config.new(default_args.merge(args))


### PR DESCRIPTION
- Minor bugfix where we missed one spot in the feature code for renaming `implicit_record_templates` to `implicit_records_templates` following feedback from https://github.com/Shopify/record_store/pull/185#discussion_r533545989