### PR TITLE
add validation to zone to detect duplicate record keys

### DIFF
--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.4.1'.freeze
+  VERSION = '6.5.0'.freeze
 end

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -20,6 +20,7 @@ module RecordStore
     validate :validate_provider_can_handle_zone_records
     validate :validate_no_empty_non_terminal
     validate :validate_can_handle_alias_records
+    validate :validate_no_duplicate_keys
 
     class << self
       def download(name, provider_name, **write_options)
@@ -70,10 +71,11 @@ module RecordStore
       end
     end
 
-    def initialize(name:, records: [], config: {})
+    def initialize(name:, records: [], config: {}, abstract_syntax_trees: {})
       @name = Record.ensure_ends_with_dot(name)
       @config = RecordStore::Zone::Config.new(config.deep_symbolize_keys)
       @records = build_records(records)
+      @abstract_syntax_trees = abstract_syntax_trees
     end
 
     def build_changesets(all: false)
@@ -306,6 +308,35 @@ module RecordStore
       return unless alias_record
 
       errors.add(:records, "ALIAS record should be defined on the root of the zone: #{alias_record}")
+    end
+
+    def validate_no_duplicate_keys
+      @abstract_syntax_trees.each do |filename, ast|
+        validate_no_duplicate_keys_in_node(filename, ast)
+      end
+    end
+
+    def validate_no_duplicate_keys_in_node(filename, node)
+      if node.mapping?
+        keys = node
+          .children
+          .each_slice(2)
+          .map(&:first)
+          .map(&:value)
+          .sort
+        dup_keys = keys
+          .find_all { |k| keys.count(k) > 1 }
+          .uniq
+        unless dup_keys.empty?
+          location = "#{File.basename(filename)}:#{node.start_line}"
+          description = "multiple definitions for keys #{dup_keys}"
+          errors.add(:records, "#{location}: #{description}")
+        end
+      end
+
+      node.children&.each do |child|
+        validate_no_duplicate_keys_in_node(filename, child)
+      end
     end
   end
 end

--- a/lib/record_store/zone/yaml_definitions.rb
+++ b/lib/record_store/zone/yaml_definitions.rb
@@ -66,7 +66,10 @@ module RecordStore
         Dir["#{dir}/#{name}/*__*.yml"].each do |record_file|
           definition['records'] += load_yml_record_definitions(name, record_file)
         end
-        Zone.new(name: name, records: definition['records'], config: definition['config'])
+
+        asts = { filename => Psych.parse_file(filename) }
+
+        Zone.new(name: name, records: definition['records'], config: definition['config'], abstract_syntax_trees: asts)
       end
 
       def load_yml_record_definitions(name, record_file)

--- a/test/fixtures/config/dummy/zones/dup-keys.com.yml
+++ b/test/fixtures/config/dummy/zones/dup-keys.com.yml
@@ -1,0 +1,13 @@
+dup-keys.com:
+  config:
+    providers:
+      - DNSimple
+  records:
+    - type: CNAME
+      fqdn: www.dup-keys.com.
+      ttl: 60
+      cname: dup-keys.com.
+      type: CNAME
+      fqdn: other.dup-keys.com.
+      ttl: 60
+      cname: dup-keys.com.

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -519,6 +519,15 @@ class ZoneTest < Minitest::Test
     end
   end
 
+  def test_zone_validates_no_duplicate_keys
+    zone = Zone.find('dup-keys.com')
+    assert(!zone.valid?)
+    assert_equal(zone.errors.size, 1)
+    err = zone.errors.first
+    assert_equal(err.attribute, :records)
+    assert(err.message.match(/multiple definitions for keys \["cname", "fqdn", "ttl", "type"\]/))
+  end
+
   def test_implicit_record_injection_only_injects_for_matching_records
     zone = Zone.new(
       name: 'zone-with-implicit-records.com',


### PR DESCRIPTION
# What this does

Considers records in a zone in particular yaml file to be invalid if there are any records which have duplicate keys (which would cause the most recent definition of the key to silently clobber any previous definitions)

# What this does not

Considers all records in a zone across any yaml files. I don't think it's actually possible to have a conflict of this kind given that the secondary yaml files that can exist in a subdir are only for specific records though.

I still left `abstract_syntax_trees` as a plural to map the filename to the ast, though, because it's more technically correct to consider a zone as made up of at least but not necessarily exactly 1 yaml document.