### PR TITLE
Bug: Initialize filters if they don't exist in the template file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.5.2
+- Ensure filters for implicit_records, `except_record` and `conflict_with`, are truly optional [BUGFIX]
+
 ## 6.5.1
 
 Add support for a new parameter in the implicit records templates:

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.5.1'.freeze
+  VERSION = '6.5.2'.freeze
 end

--- a/lib/record_store/zone/config/implicit_record_template.rb
+++ b/lib/record_store/zone/config/implicit_record_template.rb
@@ -28,7 +28,7 @@ module RecordStore
             template_file = File.read(filepath)
 
             template_file_yaml = YAML.load(template_file).deep_symbolize_keys
-            filters_for_records_to_template = template_file_yaml[:each_record] || []
+            filters_for_records_to_template = template_file_yaml[:each_record]
             filters_for_records_to_exclude = template_file_yaml[:except_record] || []
 
             new(template: ERB.new(template_file),

--- a/lib/record_store/zone/config/implicit_record_template.rb
+++ b/lib/record_store/zone/config/implicit_record_template.rb
@@ -70,8 +70,9 @@ module RecordStore
         attr_reader :template, :filters_for_records_to_template, :filters_for_records_to_exclude
 
         def should_inject?(template_records:, current_records:)
+          conflict_with = template_records[:conflict_with] || []
           current_records.none? do |record|
-            template_records[:conflict_with].any? do |filter|
+            conflict_with.any? do |filter|
               record_match?(record: record, filter: filter)
             end
           end

--- a/lib/record_store/zone/config/implicit_record_template.rb
+++ b/lib/record_store/zone/config/implicit_record_template.rb
@@ -28,8 +28,8 @@ module RecordStore
             template_file = File.read(filepath)
 
             template_file_yaml = YAML.load(template_file).deep_symbolize_keys
-            filters_for_records_to_template = template_file_yaml[:each_record]
-            filters_for_records_to_exclude = template_file_yaml[:except_record]
+            filters_for_records_to_template = template_file_yaml[:each_record] || []
+            filters_for_records_to_exclude = template_file_yaml[:except_record] || []
 
             new(template: ERB.new(template_file),
                 filters_for_records_to_template: filters_for_records_to_template,


### PR DESCRIPTION
Currently, you see nil errors when any of the optional filters are not present (`except_record`  or `conflict_with`). This fix initializes those variables if any of those filters are not present in the template file.