### PR TITLE
fix out-of-date console/cli

### DIFF
--- a/lib/record_store.rb
+++ b/lib/record_store.rb
@@ -44,6 +44,7 @@ module RecordStore
   class << self
     attr_writer :secrets_path
     attr_writer :zones_path
+    attr_writer :implicit_records_templates_path
 
     def secrets_path
       @secrets_path ||= File.expand_path(config.fetch('secrets_path'), File.dirname(config_path))

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -7,7 +7,7 @@ module RecordStore
 
     def initialize(*args)
       super
-      RecordStore.config_path = options.fetch('config', "#{Dir.pwd}/config.yml")
+      RecordStore.config_path = options.fetch('config', "#{Dir.pwd}/template/config.yml")
     end
 
     def self.exit_on_failure?

--- a/template/zones/dynect.example.com.yml
+++ b/template/zones/dynect.example.com.yml
@@ -5,7 +5,7 @@ dynect.example.com:
     ignore_patterns:
     - type: NS
       fqdn: dynect.example.com.
-    implicit_record_templates:
+    implicit_records_templates:
     - implicit_example.yml.erb
   records:
   - type: A


### PR DESCRIPTION
Fixes issues with `./bin/console` and `/bin/record-store list` due to (I assume) some past directory reorganizing and small code shuffles that happened without tests to recognize it caused breakages in these utility scripts.