### PR TITLE
account for race in mutex usage

### DIFF
--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -61,8 +61,11 @@ module RecordStore
           Thread.new do
             current_zone = nil
             while zones.any?
-              mutex.synchronize { current_zone = zones.shift }
-              mutex.synchronize { modified_zones << current_zone } unless current_zone.unchanged?
+              mutex.synchronize do
+                next unless zones.any? # recheck zones since there's a race in the while
+                current_zone = zones.shift
+                modified_zones << current_zone unless current_zone.unchanged?
+              end
             end
           end
         end.each(&:join)


### PR DESCRIPTION
Had a fun error running tests just once - seems very intermittent:

```
  2) Error:
ZoneTest#test_modified_returns_all_zones_with_changes:
NoMethodError: undefined method `unchanged?' for nil:NilClass
    record_store/lib/record_store/zone.rb:66:in `block (2 levels) in modified'
```

I can't be 100% sure what I'm doing addresses the issue, but it seems likely since ignoring race conditions I'm not sure how else you'd end up with a nil `current_zone`.

Also just made it one lock/unlock action on the mutex