### PR TITLE
Bump gem version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 6.5.3
-- Adds check to detect shadowed records, for when a record being added to a zone in record-store will have no effect because it is shadowed by another record.
+- Adds check for detecting shadowed records, used when a record being added to a zone in record-store will have no effect because it is shadowed by another record.
 
 ## 6.5.2
 - Ensure filters for implicit_records, `except_record` and `conflict_with`, are truly optional [BUGFIX]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.5.3
+- Adds check to detect shadowed records, for when a record being added to a zone in record-store will have no effect because it is shadowed by another record.
+
 ## 6.5.2
 - Ensure filters for implicit_records, `except_record` and `conflict_with`, are truly optional [BUGFIX]
 

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.5.2'.freeze
+  VERSION = '6.5.3'.freeze
 end


### PR DESCRIPTION
This PR releases record_store gem version 6.5.3 to add support for shadowed record detection. 

Related to https://github.com/Shopify/record_store/pull/191