### PR TITLE
Revert path change

### DIFF
--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -7,7 +7,7 @@ module RecordStore
 
     def initialize(*args)
       super
-      RecordStore.config_path = options.fetch('config', "#{Dir.pwd}/template/config.yml")
+      RecordStore.config_path = options.fetch('config', "#{Dir.pwd}/config.yml")
     end
 
     def self.exit_on_failure?


### PR DESCRIPTION
Reverts the path change, introduced in [192](https://github.com/Shopify/record_store/pull/192/files#diff-baf2a5717b6a8c0a807c936232471e4f13dc4c09c93c07fcb45c2b7bd6495af0R10) as it seems to be blocking deploys. 