### PR TITLE
Update Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,8 @@
-inherit_from:
-  - https://shopify.github.io/ruby-style-guide/rubocop.yml
+inherit_gem:
+  rubocop-shopify: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6.4
   Exclude:
     - vendor/**/*
   UseCache: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,12 +8,33 @@ AllCops:
   UseCache: true
   CacheRootDirectory: tmp/rubocop
 
+Naming/InclusiveLanguage:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/QuotedSymbols:
   Enabled: false
 
 Style/MethodCallWithArgsParentheses:
   Include:
     - '**/*.rb'
 
-Style/ClassAndModuleChildren:
+Style/StringLiterals:
+  Enabled: false
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+Style/WordArray:
   Enabled: false

--- a/lib/record_store.rb
+++ b/lib/record_store.rb
@@ -53,7 +53,7 @@ module RecordStore
     def zones_path
       @zones_path ||= Pathname.new(
         File.expand_path(config.fetch('zones_path'),
-        File.dirname(config_path)),
+          File.dirname(config_path)),
       ).realpath.to_s
     end
 
@@ -64,7 +64,7 @@ module RecordStore
     def implicit_records_templates_path
       @implicit_records_templates_path ||= Pathname.new(
         File.expand_path(config.fetch('implicit_records_templates_path'),
-        File.dirname(config_path)),
+          File.dirname(config_path)),
       ).realpath.to_s
     end
 

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -193,14 +193,12 @@ module RecordStore
 
     desc 'secrets', 'Decrypts DynECT credentials'
     def secrets
-      environment = begin
-        if ENV['PRODUCTION']
-          'production'
-        elsif ENV['CI']
-          'ci'
-        else
-          'dev'
-        end
+      environment = if ENV['PRODUCTION']
+        'production'
+      elsif ENV['CI']
+        'ci'
+      else
+        'dev'
       end
 
       secrets = %x(ejson decrypt #{RecordStore.secrets_path.sub(/\.json\z/, ".#{environment}.ejson")})

--- a/lib/record_store/provider.rb
+++ b/lib/record_store/provider.rb
@@ -3,6 +3,7 @@ require 'resolv'
 module RecordStore
   class Provider
     class Error < StandardError; end
+
     class UnparseableBodyError < Error; end
 
     class << self
@@ -152,24 +153,22 @@ module RecordStore
         )
 
         loop do
-          begin
-            return yield
-          rescue UnparseableBodyError
-            raise if max_retries <= 0
-            max_retries -= 1
+          return yield
+        rescue UnparseableBodyError
+          raise if max_retries <= 0
+          max_retries -= 1
 
-            waiter.wait(message: 'Waiting to retry after receiving an unparseable response')
-          rescue Net::OpenTimeout, Errno::ETIMEDOUT
-            raise if max_timeouts <= 0
-            max_timeouts -= 1
+          waiter.wait(message: 'Waiting to retry after receiving an unparseable response')
+        rescue Net::OpenTimeout, Errno::ETIMEDOUT
+          raise if max_timeouts <= 0
+          max_timeouts -= 1
 
-            $stderr.puts('Retrying after a connection timeout')
-          rescue Errno::ECONNRESET
-            raise if max_conn_resets <= 0
-            max_conn_resets -= 1
+          $stderr.puts('Retrying after a connection timeout')
+        rescue Errno::ECONNRESET
+          raise if max_conn_resets <= 0
+          max_conn_resets -= 1
 
-            waiter.wait
-          end
+          waiter.wait
         end
       end
     end

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -20,12 +20,10 @@ module RecordStore
       def retrieve_current_records(zone:, stdout: $stdout)
         retry_on_connection_errors do
           session.zones.all_records(account_id, zone).data.map do |record|
-            begin
-              build_from_api(record, zone)
-            rescue StandardError
-              stdout.puts "Cannot build record: #{record}"
-              raise
-            end
+            build_from_api(record, zone)
+          rescue StandardError
+            stdout.puts "Cannot build record: #{record}"
+            raise
           end.compact
         end
       end

--- a/lib/record_store/provider/dynect.rb
+++ b/lib/record_store/provider/dynect.rb
@@ -36,11 +36,9 @@ module RecordStore
       def retrieve_current_records(zone:, stdout: $stdout)
         session.get_all_records(zone).body.fetch('data').flat_map do |_type, records|
           records.map do |record_body|
-            begin
-              build_from_api(record_body)
-            rescue StandardError
-              stdout.puts "Cannot build record: #{record_body}"
-            end
+            build_from_api(record_body)
+          rescue StandardError
+            stdout.puts "Cannot build record: #{record_body}"
           end
         end.compact
       end

--- a/lib/record_store/provider/google_cloud_dns.rb
+++ b/lib/record_store/provider/google_cloud_dns.rb
@@ -22,13 +22,11 @@ module RecordStore
 
           # Unroll each record set into multiple records
           record_set.data.map do |record|
-            begin
-              record_set_member = record_set.dup
-              record_set_member.data = [record]
-              build_from_api(record_set_member)
-            rescue StandardError
-              stdout.puts "Cannot build record: #{record}"
-            end
+            record_set_member = record_set.dup
+            record_set_member.data = [record]
+            build_from_api(record_set_member)
+          rescue StandardError
+            stdout.puts "Cannot build record: #{record}"
           end
         end
 
@@ -44,12 +42,10 @@ module RecordStore
       private
 
       def session
-        @dns ||= begin
-          Google::Cloud::Dns.new(
-            project_id: secrets.fetch('project_id'),
-            credentials: Google::Cloud::Dns::Credentials.new(secrets),
-          )
-        end
+        @dns ||= Google::Cloud::Dns.new(
+          project_id: secrets.fetch('project_id'),
+          credentials: Google::Cloud::Dns::Credentials.new(secrets),
+        )
       end
 
       def secrets

--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -50,7 +50,7 @@ module RecordStore
       # Downloads all the records from the provider.
       #
       # Returns: an array of `Record` for each record in the provider's zone
-      def retrieve_current_records(zone:, stdout: $stdout) # rubocop:disable Lint/UnusedMethodArgument
+      def retrieve_current_records(zone:, stdout: $stdout)
         records_for_zone(zone)
           .flat_map { |short_record| build_from_api(short_record) }
           .compact

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -53,7 +53,7 @@ module RecordStore
         (ENV['RECORD_STORE_MAX_THREADS'] || DEFAULT_MAX_PARALLEL_THREADS).to_i
       end
 
-      def modified(verbose: false) # rubocop:disable Lint/UnusedMethodArgument
+      def modified(verbose: false)
         modified_zones = []
         mutex = Mutex.new
         zones = all
@@ -85,10 +85,8 @@ module RecordStore
     end
 
     def build_changesets(all: false)
-      @changesets ||= begin
-        providers.map do |provider|
-          Changeset.build_from(provider: provider, zone: self, all: all)
-        end
+      @changesets ||= providers.map do |provider|
+        Changeset.build_from(provider: provider, zone: self, all: all)
       end
     end
 

--- a/lib/record_store/zone/config/implicit_record_template.rb
+++ b/lib/record_store/zone/config/implicit_record_template.rb
@@ -32,8 +32,8 @@ module RecordStore
             filters_for_records_to_exclude = template_file_yaml[:except_record] || []
 
             new(template: ERB.new(template_file),
-                filters_for_records_to_template: filters_for_records_to_template,
-                filters_for_records_to_exclude: filters_for_records_to_exclude)
+              filters_for_records_to_template: filters_for_records_to_template,
+              filters_for_records_to_exclude: filters_for_records_to_exclude)
           end
 
           private

--- a/lib/record_store/zone/yaml_definitions.rb
+++ b/lib/record_store/zone/yaml_definitions.rb
@@ -31,7 +31,7 @@ module RecordStore
       end
 
       def write(name, config:, records:, format: :file)
-        raise ArgumentError, "format must be :directory or :file" unless %i(file directory).include?(format)
+        raise ArgumentError, "format must be :directory or :file" unless [:file, :directory].include?(format)
         name = name.chomp('.')
         zone_file = "#{RecordStore.zones_path}/#{name}.yml"
         zone = { name => { config: config.to_hash } }

--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'rubocop', '~> 1.0.0'
+  spec.add_development_dependency 'rubocop', '~> 1.18.0'
+  spec.add_development_dependency 'rubocop-shopify', '~> 2.2.0'
   spec.add_development_dependency 'minitest-focus'
 end


### PR DESCRIPTION
Rubocop isn't working on master branch and it's because the config had changed but this repo is still configured to use the old config, resulting in a `404 "Not Found" while downloading remote config file ...` error. This PR updates it and makes rubocop runnable again.

Please note that this change generated a lot of `Correctable` offenses:
`61 files inspected, 1701 offenses detected, 1692 offenses auto-correctable`
For this, I added some custom cops to ignore a lot of the errors and then autocorrected the remaining 15. 

I'm definitely flexible when it comes to which cops to enable/disable but wanted to avoid changing too many files at once. 😄 