### PR TITLE
Emit DNSimple API error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.5.5
+- Include DNSimple validation error details in exceptions
+
 ## 6.5.4
 - Updates config path structure for build pipeline
 

--- a/lib/record_store/provider/dnsimple.rb
+++ b/lib/record_store/provider/dnsimple.rb
@@ -1,5 +1,6 @@
 require 'dnsimple'
 require_relative 'dnsimple/patch_api_header'
+require_relative 'dnsimple/patch_request_error_to_include_errors'
 
 module RecordStore
   class Provider::DNSimple < Provider

--- a/lib/record_store/provider/dnsimple/patch_request_error_to_include_errors.rb
+++ b/lib/record_store/provider/dnsimple/patch_request_error_to_include_errors.rb
@@ -1,0 +1,20 @@
+module Dnsimple
+  class RequestError < Error
+    private
+
+    alias_method :original_message_from, :message_from
+
+    def message_from(http_response)
+      message = original_message_from(http_response)
+      return unless json_response?(http_response)
+
+      base_error = http_response.parsed_response.dig("errors", "base")&.join(", ")
+      message += ": #{base_error}" unless base_error.nil?
+      message
+    end
+
+    def json_response?(http_response)
+      http_response.headers["Content-Type"]&.start_with?("application/json")
+    end
+  end
+end

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.5.4'.freeze
+  VERSION = '6.5.5'.freeze
 end

--- a/test/fixtures/vcr_cassettes/dnsimple_test_non_validation_errors_exclude_details.yml
+++ b/test/fixtures/vcr_cassettes/dnsimple_test_non_validation_errors_exclude_details.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<DNSIMPLE_BASE_URL>/v2/<DNSIMPLE_ACCOUNT_ID>/zones/does_not_exist/records?page=1&per_page=100"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - dnsimple-ruby/4.4.0
+      Authorization:
+      - Bearer <DNSIMPLE_API_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Nov 2021 21:25:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2399'
+      X-Ratelimit-Reset:
+      - '1636755906'
+      X-Work-With-Us:
+      - Love automation? So do we! https://dnsimple.com/jobs
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 3d127050-ff60-4172-a3a2-5e6ffc4eeb7a
+      X-Runtime:
+      - '0.018946'
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Zone `does_not_exist` not found"}'
+    http_version:
+  recorded_at: Fri, 12 Nov 2021 21:25:06 GMT
+recorded_with: VCR 5.0.0

--- a/test/fixtures/vcr_cassettes/dnsimple_test_validation_errors_include_details.yml
+++ b/test/fixtures/vcr_cassettes/dnsimple_test_validation_errors_include_details.yml
@@ -1,0 +1,261 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<DNSIMPLE_BASE_URL>/v2/<DNSIMPLE_ACCOUNT_ID>/zones/dns-scratch.me/records?page=1&per_page=100"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - dnsimple-ruby/4.4.0
+      Authorization:
+      - Bearer <DNSIMPLE_API_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Nov 2021 21:20:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2390'
+      X-Ratelimit-Reset:
+      - '1636752080'
+      X-Work-With-Us:
+      - Love automation? So do we! https://dnsimple.com/jobs
+      Etag:
+      - W/"2ff2c84d38c038aea13d124651166965"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4ac69e2d-b062-4ee7-bbc4-515dc84ec179
+      X-Runtime:
+      - '0.024640'
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":[{"id":347564,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns1.dnsimple.com
+        admin.dnsimple.com 1519152763 86400 7200 604800 300","ttl":3600,"priority":null,"type":"SOA","regions":["global"],"system_record":true,"created_at":"2018-02-20T18:51:04Z","updated_at":"2021-11-12T20:51:11Z"},{"id":347565,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns1.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2018-02-20T18:51:04Z","updated_at":"2018-02-20T18:51:04Z"},{"id":347566,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns2.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2018-02-20T18:51:04Z","updated_at":"2018-02-20T18:51:04Z"},{"id":347567,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns3.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2018-02-20T18:51:04Z","updated_at":"2018-02-20T18:51:04Z"},{"id":347568,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"ns4.dnsimple.com","ttl":3600,"priority":null,"type":"NS","regions":["global"],"system_record":true,"created_at":"2018-02-20T18:51:04Z","updated_at":"2018-02-20T18:51:04Z"},{"id":347593,"zone_id":"dns-scratch.me","parent_id":null,"name":"test-record","content":"10.10.10.42","ttl":86400,"priority":null,"type":"A","regions":["global"],"system_record":false,"created_at":"2018-02-20T19:41:59Z","updated_at":"2018-02-20T19:41:59Z"},{"id":347594,"zone_id":"dns-scratch.me","parent_id":null,"name":"","content":"dns-scratch.herokuapp.com","ttl":86400,"priority":null,"type":"ALIAS","regions":["global"],"system_record":false,"created_at":"2018-02-20T19:42:00Z","updated_at":"2018-02-20T19:42:00Z"},{"id":934857,"zone_id":"dns-scratch.me","parent_id":null,"name":"cname","content":"0
+        issue \"digicert.com\"","ttl":3600,"priority":null,"type":"CAA","regions":["global"],"system_record":false,"created_at":"2019-03-13T13:23:46Z","updated_at":"2019-03-13T13:23:46Z"},{"id":1714861,"zone_id":"dns-scratch.me","parent_id":null,"name":"_sshfp1","content":"4
+        2 4e0ebbeac8d2e4e73af888b20e2243e5a2a08bad6476c832c985e54b21eff4a3","ttl":3600,"priority":null,"type":"SSHFP","regions":["global"],"system_record":false,"created_at":"2020-04-16T00:37:40Z","updated_at":"2020-04-16T00:37:40Z"},{"id":2429818,"zone_id":"dns-scratch.me","parent_id":null,"name":"inconsistent-records","content":"shopify.com","ttl":60,"priority":null,"type":"CNAME","regions":["global"],"system_record":false,"created_at":"2021-11-12T20:51:11Z","updated_at":"2021-11-12T20:51:11Z"}],"pagination":{"current_page":1,"per_page":100,"total_entries":10,"total_pages":1}}'
+    http_version:
+  recorded_at: Fri, 12 Nov 2021 21:20:01 GMT
+- request:
+    method: delete
+    uri: "<DNSIMPLE_BASE_URL>/v2/<DNSIMPLE_ACCOUNT_ID>/zones/dns-scratch.me/records/2429818"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - dnsimple-ruby/4.4.0
+      Authorization:
+      - Bearer <DNSIMPLE_API_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Nov 2021 21:20:01 GMT
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2389'
+      X-Ratelimit-Reset:
+      - '1636752080'
+      X-Work-With-Us:
+      - Love automation? So do we! https://dnsimple.com/jobs
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 0aec064e-b62d-4e2e-9d13-e330f1dd061d
+      X-Runtime:
+      - '0.102828'
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version:
+  recorded_at: Fri, 12 Nov 2021 21:20:01 GMT
+- request:
+    method: post
+    uri: "<DNSIMPLE_BASE_URL>/v2/<DNSIMPLE_ACCOUNT_ID>/zones/dns-scratch.me/records"
+    body:
+      encoding: UTF-8
+      string: '{"name":"inconsistent-records","ttl":60,"type":"CNAME","content":"shopify.com"}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - dnsimple-ruby/4.4.0
+      Authorization:
+      - Bearer <DNSIMPLE_API_TOKEN>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Nov 2021 21:20:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2388'
+      X-Ratelimit-Reset:
+      - '1636752080'
+      X-Work-With-Us:
+      - Love automation? So do we! https://dnsimple.com/jobs
+      Etag:
+      - W/"ebd28fb9506f812e754262592f6acb9a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 19fcd99c-ef8d-4269-9042-9deccd5580c7
+      X-Runtime:
+      - '0.077037'
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":2429967,"zone_id":"dns-scratch.me","parent_id":null,"name":"inconsistent-records","content":"shopify.com","ttl":60,"priority":null,"type":"CNAME","regions":["global"],"system_record":false,"created_at":"2021-11-12T21:20:02Z","updated_at":"2021-11-12T21:20:02Z"}}'
+    http_version:
+  recorded_at: Fri, 12 Nov 2021 21:20:02 GMT
+- request:
+    method: post
+    uri: "<DNSIMPLE_BASE_URL>/v2/<DNSIMPLE_ACCOUNT_ID>/zones/dns-scratch.me/records"
+    body:
+      encoding: UTF-8
+      string: '{"name":"inconsistent-records","ttl":60,"type":"TXT","content":"a"}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - dnsimple-ruby/4.4.0
+      Authorization:
+      - Bearer <DNSIMPLE_API_TOKEN>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Nov 2021 21:20:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '2400'
+      X-Ratelimit-Remaining:
+      - '2387'
+      X-Ratelimit-Reset:
+      - '1636752080'
+      X-Work-With-Us:
+      - Love automation? So do we! https://dnsimple.com/jobs
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - df934424-18dd-4a22-bf56-d8c188ce70a1
+      X-Runtime:
+      - '0.032389'
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+    body:
+      encoding: UTF-8
+      string: '{"message":"Validation failed","errors":{"base":["A CNAME record exists
+        for inconsistent-records.dns-scratch.me, cannot add another record"]}}'
+    http_version:
+  recorded_at: Fri, 12 Nov 2021 21:20:02 GMT
+recorded_with: VCR 5.0.0

--- a/test/providers/dnsimple_test.rb
+++ b/test/providers/dnsimple_test.rb
@@ -492,14 +492,14 @@ class DNSimpleTest < Minitest::Test
 
     inconsistent_records = [
       Record::TXT.new(
-        fqdn:fqdn,
-        ttl:60,
+        fqdn: fqdn,
+        ttl: 60,
         txtdata: 'a',
         zone: @zone_name,
       ),
       Record::CNAME.new(
-        fqdn:fqdn,
-        ttl:60,
+        fqdn: fqdn,
+        ttl: 60,
         cname: 'shopify.com.',
         zone: @zone_name,
       )
@@ -518,7 +518,7 @@ class DNSimpleTest < Minitest::Test
       ))
 
       error = assert_raises(Dnsimple::RequestError) do
-          @dnsimple.apply_changeset(Changeset.new(
+        @dnsimple.apply_changeset(Changeset.new(
           current_records: [],
           desired_records: inconsistent_records,
           provider: RecordStore::Provider::DNSimple,
@@ -526,7 +526,10 @@ class DNSimpleTest < Minitest::Test
         ))
       end
 
-      assert_equal "Validation failed: A CNAME record exists for inconsistent-records.dns-scratch.me, cannot add another record", error.message
+      assert_equal(
+        "Validation failed: A CNAME record exists for inconsistent-records.dns-scratch.me, cannot add another record",
+        error.message
+      )
     end
   end
 

--- a/test/providers/dnsimple_test.rb
+++ b/test/providers/dnsimple_test.rb
@@ -477,6 +477,59 @@ class DNSimpleTest < Minitest::Test
     end
   end
 
+  def test_non_validation_errors_exclude_details
+    VCR.use_cassette('dnsimple_test_non_validation_errors_exclude_details') do
+      error = assert_raises(Dnsimple::NotFoundError) do
+        @dnsimple.retrieve_current_records(zone: "does_not_exist")
+      end
+
+      assert_equal("Zone `does_not_exist` not found", error.message)
+    end
+  end
+
+  def test_validation_errors_include_details
+    fqdn = ['inconsistent-records', @zone_name].join('.') + '.'
+
+    inconsistent_records = [
+      Record::TXT.new(
+        fqdn:fqdn,
+        ttl:60,
+        txtdata: 'a',
+        zone: @zone_name,
+      ),
+      Record::CNAME.new(
+        fqdn:fqdn,
+        ttl:60,
+        cname: 'shopify.com.',
+        zone: @zone_name,
+      )
+    ]
+
+    VCR.use_cassette('dnsimple_test_validation_errors_include_details') do
+      existing_records = @dnsimple.retrieve_current_records(zone: @zone_name).select do |record|
+        record.fqdn == fqdn
+      end
+
+      @dnsimple.apply_changeset(Changeset.new(
+        current_records: existing_records,
+        desired_records: [],
+        provider: RecordStore::Provider::DNSimple,
+        zone: @zone_name,
+      ))
+
+      error = assert_raises(Dnsimple::RequestError) do
+          @dnsimple.apply_changeset(Changeset.new(
+          current_records: [],
+          desired_records: inconsistent_records,
+          provider: RecordStore::Provider::DNSimple,
+          zone: @zone_name,
+        ))
+      end
+
+      assert_equal "Validation failed: A CNAME record exists for inconsistent-records.dns-scratch.me, cannot add another record", error.message
+    end
+  end
+
   def test_zones_returns_list_of_zones_managed_by_provider
     VCR.use_cassette('dnsimple_zones') do
       assert_equal(@dnsimple.zones, [@zone_name])


### PR DESCRIPTION
**What's the problem?**

When the DNSimple API returns validation errors, although the type of the API error is included in exceptions (`Validation failed`), the details of the error are omitted.

For example, if we somehow attempted to put a zone into an inconsistent state (and this passed through the validations in descendants of `RecordStore::Record`) an exception with the following message would be emitted by `record_store`:

```
Dnsimple::RequestError: Validation failed
```

This doesn't give us much to go on as far as how to do these validations in `RecordStore` itself.

**How does this fix it?**

It appears as though the DNSimple API includes these details in the `errors` field of responses.  This change simply ensures that these details are included in exceptions.

So, instead of the error above, this change would add a little bit more flavour:

```
Validation failed: A CNAME record exists for inconsistent-records.dns-scratch.me, cannot add another record
```

**What do I need from a review**

- Another set of eyes for style.
- Any situations where we'd break where error responses do not contain these extra fields.  I added a test case, but feel free to suggest more testing here.

**Follow up**

And don't worry.  I'll follow up by trying to get this change into upstream.  If they accept it, we can upgrade the dependancy here, and remove the monkey-patch.