### PR TITLE
it seems hash to kwargs is not implied any more

### DIFF
--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.5.5'.freeze
+  VERSION = '6.5.6'.freeze
 end

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -79,7 +79,7 @@ module RecordStore
 
     def initialize(name:, records: [], config: {}, abstract_syntax_trees: {})
       @name = Record.ensure_ends_with_dot(name)
-      @config = RecordStore::Zone::Config.new(config.deep_symbolize_keys)
+      @config = RecordStore::Zone::Config.new(**config.deep_symbolize_keys)
       @records = build_records(records)
       @abstract_syntax_trees = abstract_syntax_trees
     end


### PR DESCRIPTION
I found a reference to ruby 2.7 deprecating automatic conversion of a hash to kwargs, but can't find a changelog reference that says it was fully removed at some point between 2.7 and 3.1

Regardless: I can say this is broken on ruby 3.1 because it wants kwargs, and doing this fixes it.