### PR TITLE
use safe load since 3.1 requires it

### DIFF
--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.5.6'.freeze
+  VERSION = '6.5.7'.freeze
 end

--- a/lib/record_store/zone/config/implicit_record_template.rb
+++ b/lib/record_store/zone/config/implicit_record_template.rb
@@ -27,7 +27,7 @@ module RecordStore
             filepath = template_filepath_for(filename: filename)
             template_file = File.read(filepath)
 
-            template_file_yaml = YAML.load(template_file).deep_symbolize_keys
+            template_file_yaml = YAML.safe_load(template_file, permitted_classes: [Regexp]).deep_symbolize_keys
             filters_for_records_to_template = template_file_yaml[:each_record]
             filters_for_records_to_exclude = template_file_yaml[:except_record] || []
 
@@ -96,8 +96,9 @@ module RecordStore
         def template_record_for(record:, current_records:)
           context = TemplateContext.build(record: record, current_records: current_records)
 
-          YAML.load(
-            template.result(context.fetch_binding)
+          YAML.safe_load(
+            template.result(context.fetch_binding),
+            permitted_classes: [Regexp],
           ).deep_symbolize_keys
         end
       end


### PR DESCRIPTION
Ruby 3.0 or 3.1 uses Psych 4.0+, Psych 4.0+ uses `safe_load` as the default for `YAML.load`, so now `YAML.load` will refuse to deserialize, among other things, regexes, which are used in places like [this](https://github.com/Shopify/record-store/blob/master/templates/implicit_records/acme-challenge.yml.erb#L12).

Older versions of ruby won't recognize the `permitted_classes` keyword in `load`, so we have to use `safe_load` directly to make things worth across ruby versions.