### PR TITLE
Update to ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.7.1 ]
+        ruby: [ 2.7.1, 3.1.0 ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.5.7'.freeze
+  VERSION = '6.5.8'.freeze
 end

--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'google-cloud-dns', '~> 0.31.0'
   spec.add_runtime_dependency 'ruby-limiter', '~> 1.0', '>= 1.0.1'
   spec.add_runtime_dependency 'ns1'
-  spec.add_runtime_dependency 'oci', '~> 2.6.0'
+  spec.add_runtime_dependency 'oci', '~> 2.14.0'
 
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake'

--- a/test/zone/config_test.rb
+++ b/test/zone/config_test.rb
@@ -31,7 +31,7 @@ example.com:
     tmp_config.close
 
     zone_name, definition = YAML.load_file(tmp_config.path).first
-    zone = Zone.new(definition.deep_symbolize_keys.merge(name: zone_name))
+    zone = Zone.new(**definition.deep_symbolize_keys.merge(name: zone_name))
 
     assert_equal([{ type: 'NS' }, { type: 'A', fqdn: 'a.example.com.' }],
       zone.config.ignore_patterns.map(&:to_hash))

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -715,7 +715,7 @@ class ZoneTest < Minitest::Test
       implicit_records_templates: [],
     }
 
-    Zone::Config.new(default_args.merge(args))
+    Zone::Config.new(**default_args.merge(args))
   end
 
   def with_zones_tmpdir


### PR DESCRIPTION
Needed to bump one dependency which had some deprecated use of URI, needed to account for some cases where now-removed behaviour of implicit hash to kwargs conversion happened.