### PR TITLE
account for model validation errors in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.5.10
+- print the full error for ActiveModel::Error errors
+
 ## 6.5.9
 - Relax version requirements for the google-cloud-dns gem
 

--- a/lib/record_store/cli.rb
+++ b/lib/record_store/cli.rb
@@ -279,9 +279,7 @@ module RecordStore
         invalid_zones << zone.unrooted_name
 
         puts "#{zone.unrooted_name} definition is not valid:"
-        zone.errors.each do |field, msg|
-          puts " - #{field}: #{msg}"
-        end
+        puts zone.errors.full_messages.map { |msg| " - #{msg}" }
 
         invalid_records = zone.records.reject(&:valid?)
         puts '  Invalid records' unless invalid_records.empty?

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.5.9'.freeze
+  VERSION = '6.5.10'.freeze
 end


### PR DESCRIPTION
Recently had an ugly error in `record-store` [here](https://buildkite.com/shopify/record-store/builds/9961#018236c1-57ba-4bd5-b54f-02494bb22ce0)

![](https://screenshot.click/25-31-j5xde-31x1q.png)

This is a quick and dirty fix, but I'm not sure it's worth trying hard given the underway plans to drop record store anyway.