### PR TITLE
Fix handling of SRV records in NS1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 6.5.11
+- Fix updates of SRV records in using the NS1 provider
+
 ## 6.5.10
 - print the full error for ActiveModel::Error errors
 

--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -14,8 +14,8 @@ module RecordStore
           when 'SPF', 'TXT'
             [answer]
           when 'SRV'
-            rdata = answer.split
-            [rdata[0].to_i, rdata[1].to_i, rdata[2].to_i, rdata[3]]
+            priority, weight, port, host = answer.split
+            [priority.to_i, weight.to_i, port.to_i, Record.ensure_ends_with_dot(host)]
           else
             answer.split
           end

--- a/lib/record_store/provider/ns1.rb
+++ b/lib/record_store/provider/ns1.rb
@@ -13,6 +13,9 @@ module RecordStore
           rrdata_fields = case type
           when 'SPF', 'TXT'
             [answer]
+          when 'SRV'
+            rdata = answer.split
+            [rdata[0].to_i, rdata[1].to_i, rdata[2].to_i, rdata[3]]
           else
             answer.split
           end

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '6.5.10'.freeze
+  VERSION = '6.5.11'.freeze
 end


### PR DESCRIPTION
`from_short_api_answer` failed to cast to integers the SRV values. Other api answer parsers did do it, which led to ID mismatches while trying to update a SRV record.

![image](https://user-images.githubusercontent.com/8549680/190704897-639330e5-f34a-4e6a-a8de-1633e4e027b0.png)

This fix was tested in an application that used this gem manually to unblock the deployment pipeline.