### PR TITLE
Allow underscores in the middle of CNAMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 7.0.1
+- Allow an underscore in the middle of a CNAME record
+
 ## 7.0.0
 - Validate that there are no A/AAAA record conflicts with ALIAS records
 

--- a/lib/record_store/record.rb
+++ b/lib/record_store/record.rb
@@ -1,6 +1,6 @@
 module RecordStore
   class Record
-    FQDN_REGEX  = /\A(\*\.)?([a-z0-9_]+(-[a-z0-9]+)*\._?)+[a-z]{2,}\.\Z/i
+    FQDN_REGEX  = /\A(\*\.)?([a-z0-9_]+(-[_a-z0-9]+)*\._?)+[a-z]{2,}\.\Z/i
     CNAME_REGEX = /\A(\*\.)?([a-z0-9_]+((-|--)?[a-z0-9]+)*\._?)+[a-z]{2,}\.\Z/i
 
     include ActiveModel::Validations

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '7.0.0'.freeze
+  VERSION = '7.0.1'.freeze
 end

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -58,6 +58,21 @@ class RecordTest < Minitest::Test
     assert_equal(5, record.ttl)
   end
 
+  def test_build_cname_from_yaml_definition
+    yaml_snippet = <<-YAML
+      type: CNAME
+      fqdn: _acme-challenge_accepted.somewhere.example.com.
+      cname: challenge.dns-test.shopify.io.
+      ttl: 5 # TTL times are in seconds
+    YAML
+
+    record = Record.build_from_yaml_definition(YAML.load(yaml_snippet).symbolize_keys)
+
+    assert_kind_of(Record::CNAME, record)
+    assert_equal("_acme-challenge_accepted.somewhere.example.com.", record.fqdn)
+    assert(record.valid?)
+  end
+
   def test_downcases_fqdn
     yaml_snippet = <<-YAML
       type: TXT


### PR DESCRIPTION
Fix #240 

We've hit an issue where a Google Certificate Manager requires creating a record like this:
`_acme-challenge_fl6lu2jzu7jamg5z.bcldb-integration-dev.shopifysvc.com.`.

Unfortunately that's not currently allowed by record_store as it fails validation if there's an underscore in the middle of the FQDN.

This PR relaxes that requirement.