### PR TITLE
Resolve srv record bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 8.0.3
+- Fix SRV records in Cloudflare
+
 ## 8.0.2
 - Fix Changesets to be case-insensitive
 

--- a/lib/record_store/provider/cloudflare.rb
+++ b/lib/record_store/provider/cloudflare.rb
@@ -132,7 +132,7 @@ module RecordStore
         when Record::CAA
           api_body[:data] = record.rdata
         when Record::SRV
-          api_body[:data] = rdata
+          api_body[:data] = record.rdata
         when Record::ALIAS
           api_body[:type] = 'CNAME'
           api_body[:content] = record.rdata_txt

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '8.0.2'.freeze
+  VERSION = '8.0.3'.freeze
 end

--- a/test/providers/cloudflare_test.rb
+++ b/test/providers/cloudflare_test.rb
@@ -363,6 +363,32 @@ class CloudflareTest < Minitest::Test
     assert_equal(expected_api_body, api_body)
   end
 
+  def test_build_api_body_for_srv_record
+    record = Record::SRV.new(
+      fqdn: '_sip._tcp.record-store-dns-tests.shopitest.com.',
+      ttl: 3600,
+      priority: 10,
+      weight: 20,
+      port: 5060,
+      target: 'sip.record-store-dns-tests.shopitest.com.',
+    )
+    api_body = @cloudflare.send(:build_api_body, record)
+
+    expected_api_body = {
+      name: '_sip._tcp.record-store-dns-tests.shopitest.com.',
+      ttl: 3600,
+      type: 'SRV',
+      data: {
+        priority: 10,
+        weight: 20,
+        port: 5060,
+        target: 'sip.record-store-dns-tests.shopitest.com.'
+      }
+    }
+
+    assert_equal(expected_api_body, api_body)
+  end
+
   def test_zones_returns_empty_array_when_api_response_is_empty
     page = 1
     per_page = 50


### PR DESCRIPTION
### Problem 

We weren't getting rdata for SRV records correctly 

### Solution

Update the code to get `record.rdata`
I also bumped the version of record_store from 8.0.2 to 8.0.3 
