### PR TITLE
Fix test failures due to example.com DNS hosting change to Cloudflare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 8.0.11
+- Modified Zone#fetch_authority to handle SOA answer sections from authoritative servers
+
 ## 8.0.10
 - Fix Cloudflare provider to skip empty changesets
 - Add TXT record denormalization for DNSimple provider

--- a/lib/record_store/version.rb
+++ b/lib/record_store/version.rb
@@ -1,3 +1,3 @@
 module RecordStore
-  VERSION = '8.0.10'.freeze
+  VERSION = '8.0.11'.freeze
 end

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -143,6 +143,12 @@ module RecordStore
 
     def fetch_authority(nameserver = ROOT_SERVERS.sample)
       authority = fetch_soa(nameserver) do |reply, _name|
+        # If we get a valid SOA answer, the nameserver is authoritative, so fetch NS records directly
+        if reply.answer.any? && reply.answer.first[0].to_s == unrooted_name
+          break fetch_ns_records(nameserver)
+        end
+
+        # For NXDOMAIN or referral responses, continue with authority section
         break if reply.answer.any?
 
         raise "No authority found (#{name})" if reply.authority.none?
@@ -151,7 +157,14 @@ module RecordStore
       end
 
       # candidate DNS name is returned instead when NXDomain or other error
-      return if unrooted_name.casecmp?(Array(authority).first.to_s)
+      # In this case, query the parent domain's NS records
+      if authority.is_a?(Array) && authority.first.is_a?(Resolv::DNS::Name) && unrooted_name.casecmp?(authority.first.to_s)
+        # Extract parent domain from unrooted_name (e.g., "sub.example.com" -> "example.com")
+        parts = unrooted_name.split('.')
+        return nil if parts.length <= 1  # No parent domain available (TLD)
+        parent_domain = parts[1..-1].join('.') + '.'
+        return fetch_ns_records_for_domain(parent_domain, nameserver)
+      end
 
       authority
     end
@@ -161,6 +174,20 @@ module RecordStore
     def fetch_soa(nameserver, &block)
       Resolv::DNS.open(nameserver: nameserver) do |resolv|
         resolv.fetch_resource(name, Resolv::DNS::Resource::IN::SOA, &block)
+      end
+    end
+
+    def fetch_ns_records(nameserver)
+      fetch_ns_records_for_domain(name, nameserver)
+    end
+
+    def fetch_ns_records_for_domain(domain, nameserver)
+      Resolv::DNS.open(nameserver: nameserver) do |resolv|
+        resources = resolv.getresources(domain, Resolv::DNS::Resource::IN::NS)
+        return nil if resources.empty?
+        resources.map.with_index do |ns, index|
+          Record::NS.new(ttl: ns.ttl, fqdn: domain, nsdname: ns.name.to_s, record_id: index)
+        end
       end
     end
 

--- a/lib/record_store/zone.rb
+++ b/lib/record_store/zone.rb
@@ -158,10 +158,12 @@ module RecordStore
 
       # candidate DNS name is returned instead when NXDomain or other error
       # In this case, query the parent domain's NS records
-      if authority.is_a?(Array) && authority.first.is_a?(Resolv::DNS::Name) && unrooted_name.casecmp?(authority.first.to_s)
+      if authority.is_a?(Array) && authority.first.is_a?(Resolv::DNS::Name) &&
+          unrooted_name.casecmp?(authority.first.to_s)
         # Extract parent domain from unrooted_name (e.g., "sub.example.com" -> "example.com")
         parts = unrooted_name.split('.')
-        return nil if parts.length <= 1  # No parent domain available (TLD)
+        return if parts.length <= 1 # No parent domain available (TLD)
+
         parent_domain = parts[1..-1].join('.') + '.'
         return fetch_ns_records_for_domain(parent_domain, nameserver)
       end
@@ -185,6 +187,7 @@ module RecordStore
       Resolv::DNS.open(nameserver: nameserver) do |resolv|
         resources = resolv.getresources(domain, Resolv::DNS::Resource::IN::NS)
         return nil if resources.empty?
+
         resources.map.with_index do |ns, index|
           Record::NS.new(ttl: ns.ttl, fqdn: domain, nsdname: ns.name.to_s, record_id: index)
         end

--- a/record_store.gemspec
+++ b/record_store.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activemodel', '>= 4.2'
   spec.add_runtime_dependency 'activesupport', '>= 4.2'
+  spec.add_runtime_dependency 'csv'
   spec.add_runtime_dependency 'ejson'
   spec.add_runtime_dependency 'thor', '>= 1.4.0'
 

--- a/test/cli/info_test.rb
+++ b/test/cli/info_test.rb
@@ -35,13 +35,10 @@ module CLI
     def test_lists_authoritative_nameservers
       RecordStore::CLI.start(%w(info))
 
-      authority = <<~AUTHORITY
-        Authoritative nameservers:
-        - [NSRecord] example.com. 172800 IN NS a.iana-servers.net.
-        - [NSRecord] example.com. 172800 IN NS b.iana-servers.net.
-      AUTHORITY
-
-      assert_includes($stdout.string, authority)
+      output = $stdout.string
+      assert_includes(output, "Authoritative nameservers:")
+      assert_includes(output, "hera.ns.cloudflare.com.")
+      assert_includes(output, "elliott.ns.cloudflare.com.")
     end
   end
 end

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -678,11 +678,12 @@ class ZoneTest < Minitest::Test
   def test_fetch_authority
     zone = Zone.new(name: 'example.com')
     nameservers = zone.fetch_authority
-    expected = [
-      Record::NS.new(fqdn: 'example.com', ttl: 172_800, nsdname: 'a.iana-servers.net.'),
-      Record::NS.new(fqdn: 'example.com', ttl: 172_800, nsdname: 'b.iana-servers.net.'),
-    ]
-    assert_equal(expected, nameservers)
+
+    assert_equal 2, nameservers.count
+    nsdnames = nameservers.map(&:nsdname).sort
+    assert_equal ['elliott.ns.cloudflare.com.', 'hera.ns.cloudflare.com.'], nsdnames
+    assert_equal 'example.com.', nameservers.first.fqdn
+    assert nameservers.first.ttl > 0
   end
 
   def test_fetch_authority_handles_unreachable_host

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -679,11 +679,11 @@ class ZoneTest < Minitest::Test
     zone = Zone.new(name: 'example.com')
     nameservers = zone.fetch_authority
 
-    assert_equal 2, nameservers.count
+    assert_equal(2, nameservers.count)
     nsdnames = nameservers.map(&:nsdname).sort
-    assert_equal ['elliott.ns.cloudflare.com.', 'hera.ns.cloudflare.com.'], nsdnames
-    assert_equal 'example.com.', nameservers.first.fqdn
-    assert nameservers.first.ttl > 0
+    assert_equal(['elliott.ns.cloudflare.com.', 'hera.ns.cloudflare.com.'], nsdnames)
+    assert_equal('example.com.', nameservers.first.fqdn)
+    assert(nameservers.first.ttl > 0)
   end
 
   def test_fetch_authority_handles_unreachable_host


### PR DESCRIPTION
## Summary
- Fixed test failures caused by example.com's DNS hosting migration from IANA to Cloudflare nameservers
- Updated DNS query logic to handle authoritative SOA answers from root servers
- Added csv gem for Ruby 3.4+ compatibility

## Details

Example.com has migrated from IANA nameservers (a.iana-servers.net, b.iana-servers.net) to Cloudflare nameservers (hera.ns.cloudflare.com, elliott.ns.cloudflare.com).

Additionally, root DNS servers now return authoritative SOA answers for example.com instead of NS referrals. This required updating the `fetch_authority` method to detect when we receive an authoritative answer and fetch NS records directly.

The csv gem was also added as a runtime dependency since Ruby 3.4 removed it from the standard library, which was causing LoadError exceptions.

## Changes
- Updated test expectations in `ZoneTest#test_fetch_authority` and `CLI::InfoTest#test_lists_authoritative_nameservers` to use Cloudflare nameservers
- Modified `Zone#fetch_authority` to handle SOA answer sections from authoritative servers
- Added `fetch_ns_records` and `fetch_ns_records_for_domain` helper methods
- Added csv gem to runtime dependencies in gemspec
- Fixed NXDOMAIN handling to query parent domain NS records

## Test plan
- [x] Run `bundle exec rake test` - all tests pass (0 failures, unrelated Oracle Cloud DNS VCR errors remain)
- [x] Verify `ZoneTest#test_fetch_authority` passes with new Cloudflare nameservers
- [x] Verify `CLI::InfoTest#test_lists_authoritative_nameservers` passes
- [x] Verify all `test_fetch_authority*` tests pass including NXDOMAIN handling
- [x] Confirm csv gem resolves Ruby 3.4 compatibility issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)